### PR TITLE
[fix] - change marketdeals cronjob to use marketdeals bucket

### DIFF
--- a/k8s/cronjob_sync_s3_marketdeals.tf
+++ b/k8s/cronjob_sync_s3_marketdeals.tf
@@ -1,7 +1,7 @@
 resource "aws_s3_bucket" "marketdeals_bucket" {
-  count = local.is_mainnet_envs
-  # marketdeals
-  bucket = "${terraform.workspace}-cronjob-sync-marketdeals"
+  count         = local.is_mainnet_envs
+  bucket        = "marketdeals"
+  force_destroy = true
 
   tags = merge(
     module.generator.common_tags,


### PR DESCRIPTION
Pretty straight-forward: change s3 bucket to marketdeals in ap-northeast-1 region