### PR TITLE
[feat] - add Kong CRD for the bigger timeouts on the service side

### DIFF
--- a/k8s/kong_ingress_timeout.tf
+++ b/k8s/kong_ingress_timeout.tf
@@ -1,0 +1,25 @@
+# CRD for the KONG configuration. This is a service-level configuration.
+# Hence, you will need to annotate your service resource in k8s with the configuration.konghq.com annotation.
+# Links:
+# https://github.com/Kong/kubernetes-ingress-controller/issues/905 - example with whole setup
+# https://docs.konghq.com/kubernetes-ingress-controller/latest/references/custom-resources/#kongingress -
+#   whole KongIngress config
+
+resource "kubernetes_manifest" "kong_ingress_read_timeout" {
+  count = local.is_mainnet_envs
+  manifest = {
+    "apiVersion" = "configuration.konghq.com/v1"
+    "kind"       = "KongIngress"
+    "metadata" = {
+      "name"      = "kong-ingress-read-timeout"
+      "namespace" = kubernetes_namespace_v1.network.metadata[0].name
+      "annotations" = {
+        "kubernetes.io/ingress.class" = "kong-external-lb"
+      }
+    }
+    "proxy" = {
+      "protocol"     = "http"
+      "read_timeout" = 180000
+    }
+  }
+}


### PR DESCRIPTION
Right now for testing purposes it was done manually.
I'll create additional PR to the `filecoin-chart` repo.

Proof that manual stuff is working:
Curl had to wait 114 seconds:
```
100    75    0     0    0    75      0      0 --:--:--  0:01:54 --:--:--     0* Mark bundle as not supporting multiuse
```
Kong is also returned `Latency` headed:
`X-Kong-Upstream-Latency: 113897`


