### PR TITLE
[feat] - add new custom dashboard for volumes monitoring with alarm 

### DIFF
--- a/k8s/configs/prometheus/values.yaml
+++ b/k8s/configs/prometheus/values.yaml
@@ -59,11 +59,16 @@ alertmanager:
                 {{ end }}
       {{ end }}
 
-## Using default values from https://github.com/helm/charts/blob/master/stable/grafana/values.yaml
+## Using default values from https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml
 ##
 grafana:
   nodeSelector:
     nodeGroupName: ${get_nodegroup_selector}
+  grafana.ini:
+    unified_alerting:
+      enabled: false
+    server:
+      root_url: "https://${get_grafana_notif_url}/"
   notifiers:
     notifiers.yaml:
       notifiers:
@@ -109,6 +114,10 @@ grafana:
         datasource: Prometheus
         gnetId: 13901
         revision: 2
+      LotusVolumes:
+        datasource: Prometheus
+        gnetId: 17092
+        revision: 7
 
 ## Component scraping the kubelet and kubelet-hosted cAdvisor
 kubelet:

--- a/k8s/monitoring.tf
+++ b/k8s/monitoring.tf
@@ -16,6 +16,7 @@ resource "helm_release" "monitoring" {
       get_prometheus_storage_class = kubernetes_storage_class_v1.ebs_csi_driver_gp2.metadata[0].name
       get_kong_ingress_external    = helm_release.konghq-external.name
       get_kong_ingress_internal    = helm_release.konghq-internal.name
+      get_grafana_notif_url        = local.is_dev_envs == 1 ? "monitoring.dev.node.glif.io" : "monitoring.node.glif.io"
     })
   ]
 


### PR DESCRIPTION
What was done: 
* add new custom dashboard for volumes monitoring with alarm 
* disable unified_alerting, 
* add root url variable to make links usable
---

Example of usable link in alarm:
https://protofire.slack.com/archives/C03P9UE3QB0/p1664820400660679
Link to dashboard on the grafana.com: https://grafana.com/grafana/dashboards/17092-kubernetes-persistent-volumes/

---
I'll apply this to prod after approve on this PR.