### PR TITLE
[fix] - fix logic for ingress plugins choose and ipfs endpoints

### DIFF
--- a/k8s/modules-ingress-dev.tf
+++ b/k8s/modules-ingress-dev.tf
@@ -11,6 +11,7 @@ module "ingress-kong_cid-checker-calibrationnet" {
   get_rule_host                      = "cid.calibration.node.glif.io"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
 }
 
 module "ingress-kong_cid-checker-calibrationnet-api" {
@@ -24,6 +25,7 @@ module "ingress-kong_cid-checker-calibrationnet-api" {
   get_rule_host                      = "cid.calibration.node.glif.io"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
 }
 
 module "ingress-kong_cid-checker-another-calibrationnet" {
@@ -32,12 +34,13 @@ module "ingress-kong_cid-checker-another-calibrationnet" {
   get_global_configuration           = local.make_global_configuration
   get_ingress_http_path              = "/"
   get_ingress_pathType              = "Prefix"
-  get_ingress_backend_service_name   = "cid-checker-frontend" // the "-service" string will be added automatically
+  get_ingress_backend_service_name   = "cid-пchecker-frontend" // the "-service" string will be added automatically
   get_ingress_backend_service_port   = 80
   get_ingress_namespace              = "default"
   get_rule_host                      = "cid-another.calibration.node.glif.io"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
 }
 
 module "ingress-kong_cid-checker-another-calibrationnet-api" {
@@ -51,6 +54,7 @@ module "ingress-kong_cid-checker-another-calibrationnet-api" {
   get_rule_host                      = "cid-another.calibration.node.glif.io"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
 }
 
 ############calibration.node.glif.io##########################
@@ -84,7 +88,7 @@ module "ingress-kong_calibrationapi-ipfs-service-4001" {
   count                            = local.is_dev_envs
   source                           = "../modules/k8s_ingress"
   get_global_configuration         = local.make_global_configuration
-  get_ingress_http_path            = "/calibrationapi/ipfs/(.*)"
+  get_ingress_http_path            = "/calibrationapi/ipfs/4001/(.*)"
   get_ingress_backend_service_name = "calibrationapi-ipfs" // the "-service" string will be added automatically
   get_ingress_backend_service_port = 4001
   get_ingress_namespace            = kubernetes_namespace_v1.network.metadata[0].name
@@ -97,7 +101,7 @@ module "ingress-kong_calibrationapi-ipfs-service-8080" {
   count                            = local.is_dev_envs
   source                           = "../modules/k8s_ingress"
   get_global_configuration         = local.make_global_configuration
-  get_ingress_http_path            = "/calibrationapi/ipfs/(.*)"
+  get_ingress_http_path            = "/calibrationapi/ipfs/8080/(.*)"
   get_ingress_backend_service_name = "calibrationapi-ipfs" // the "-service" string will be added automatically
   get_ingress_backend_service_port = 8080
   get_ingress_namespace            = kubernetes_namespace_v1.network.metadata[0].name

--- a/k8s/modules-ingress-mainnet.tf
+++ b/k8s/modules-ingress-mainnet.tf
@@ -11,6 +11,7 @@ module "ingress-kong_cid-checker-mainnet" {
   get_rule_host                      = "cid.node.glif.io"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
 }
 
 module "ingress-kong_cid-checker-mainnet-api" {
@@ -24,6 +25,7 @@ module "ingress-kong_cid-checker-mainnet-api" {
   get_rule_host                      = "cid.node.glif.io"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
 }
 
 module "ingress-kong_cid-checker-another-mainnet" {
@@ -38,6 +40,7 @@ module "ingress-kong_cid-checker-another-mainnet" {
   get_rule_host                      = "cid-another.node.glif.io"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
 }
 
 module "ingress-kong_cid-checker-another-mainnet-api" {
@@ -51,6 +54,7 @@ module "ingress-kong_cid-checker-another-mainnet-api" {
   get_rule_host                      = "cid-another.node.glif.io"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
 }
 
 #############node.glif.io##########################
@@ -119,7 +123,7 @@ module "ingress-kong_space00-ipfs-service-4001" {
   count                            = local.is_mainnet_envs
   source                           = "../modules/k8s_ingress"
   get_global_configuration         = local.make_global_configuration
-  get_ingress_http_path            = "/space00/ipfs/(.*)"
+  get_ingress_http_path            = "/space00/ipfs/4001/(.*)"
   get_ingress_backend_service_name = "space00-ipfs" // the "-service" string will be added automatically
   get_ingress_backend_service_port = 4001
   get_ingress_namespace            = kubernetes_namespace_v1.network.metadata[0].name
@@ -132,7 +136,7 @@ module "ingress-kong_space00-ipfs-service-8080" {
   count                            = local.is_mainnet_envs
   source                           = "../modules/k8s_ingress"
   get_global_configuration         = local.make_global_configuration
-  get_ingress_http_path            = "/space00/ipfs/(.*)"
+  get_ingress_http_path            = "/space00/ipfs/8080/(.*)"
   get_ingress_backend_service_name = "space00-ipfs" // the "-service" string will be added automatically
   get_ingress_backend_service_port = 8080
   get_ingress_namespace            = kubernetes_namespace_v1.network.metadata[0].name

--- a/modules/k8s_ingress/locals.tf
+++ b/modules/k8s_ingress/locals.tf
@@ -4,9 +4,9 @@ locals {
   get_environment     = lookup(var.get_global_configuration, "environment", "")
   get_sub_environment = lookup(var.get_global_configuration, "sub_environment", "")
 
-  replace_url_only        = var.is_kong_transformer_header_enabled && var.is_kong_auth_header_enabled == false ? kubernetes_manifest.request_transformer_replace_url_only.0.manifest.metadata.name : ""
+  get_request_transformer = var.is_kong_auth_header_enabled && var.is_kong_transformer_header_enabled ? local.auth_header_replace_url : local.replace_url_only
   auth_header_replace_url = var.is_kong_auth_header_enabled && var.is_kong_transformer_header_enabled ? kubernetes_manifest.request_transformer_auth_header_replace_url[0].manifest.metadata.name : local.replace_url_only
-  get_request_transformer = var.is_kong_auth_header_enabled && var.is_kong_transformer_header_enabled ? local.auth_header_replace_url : ""
+  replace_url_only        = var.is_kong_transformer_header_enabled && var.is_kong_auth_header_enabled == false ? kubernetes_manifest.request_transformer_replace_url_only.0.manifest.metadata.name : ""
 
   get_cors              = var.is_kong_cors_enabled ? kubernetes_manifest.cors[0].manifest.metadata.name : ""
   get_whitelist_ips     = var.enable_whitelist_ip ? kubernetes_manifest.ip_restriction[0].manifest.metadata.name : ""


### PR DESCRIPTION
What was done:
* fix logic for ingress plugins choose and ipfs endpoints previously there was not possible to enable replace url only
* fix ipfs endpoints to add port name to the path
* add option to disable url transformer creation on the CID ingresses

Proof that ipfs+snapshot feature is working: calibration.node.glif.io/calibrationapi/ipfs/8080/ipfs/QmZRR833jB9XnJbdDVqCHExwLhHjNKU1bptuBp4MwM4pBW - caution 4GB file :grimacing: 