### PR TITLE
Add possibility to deploy multiple codebuild installations in one cluster (specifically CID Checker)

### DIFF
--- a/aws/modules_common.tf
+++ b/aws/modules_common.tf
@@ -30,7 +30,7 @@ module "codebuild_ci_cid-checker_mainnet" {
   ]
 }
 
-module "codebuild_ci_cid-checker_calibrationnet" {
+module "codebuild_ci_cid-checker_calibration" {
   count                    = local.is_dev_envs
   source                   = "../modules/codebuild"
   git_repository_name      = "cid-checker"
@@ -38,7 +38,22 @@ module "codebuild_ci_cid-checker_calibrationnet" {
   is_build_only            = true
   privileged_mode          = true
   is_build_concurrent      = false
-  specific_branch          = "calibrationnet"
+  specific_branch          = "calibration"
+
+  depends_on = [
+    aws_secretsmanager_secret.github_cd_token_secret
+  ]
+}
+
+module "codebuild_ci_cid-checker_wallaby" {
+  count                    = local.is_dev_envs
+  source                   = "../modules/codebuild"
+  git_repository_name      = "cid-checker"
+  get_global_configuration = local.make_codebuild_global_configuration
+  is_build_only            = true
+  privileged_mode          = true
+  is_build_concurrent      = false
+  specific_branch          = "wallaby"
 
   depends_on = [
     aws_secretsmanager_secret.github_cd_token_secret
@@ -59,14 +74,28 @@ module "codebuild_cd_cid-checker_mainnet" {
   ]
 }
 
-module "codebuild_cd_cid-checker_calibrationnet" {
+module "codebuild_cd_cid-checker_calibration" {
   count                    = local.is_dev_envs
   source                   = "../modules/codebuild"
   git_repository_name      = "cid-checker"
   get_global_configuration = local.make_codebuild_global_configuration
   privileged_mode          = true
   is_build_concurrent      = false
-  specific_branch          = "calibrationnet"
+  specific_branch          = "calibration"
+
+  depends_on = [
+    aws_secretsmanager_secret.github_cd_token_secret
+  ]
+}
+
+module "codebuild_cd_cid-checker_wallaby" {
+  count                    = local.is_dev_envs
+  source                   = "../modules/codebuild"
+  git_repository_name      = "cid-checker"
+  get_global_configuration = local.make_codebuild_global_configuration
+  privileged_mode          = true
+  is_build_concurrent      = false
+  specific_branch          = "wallaby"
 
   depends_on = [
     aws_secretsmanager_secret.github_cd_token_secret

--- a/aws/modules_common.tf
+++ b/aws/modules_common.tf
@@ -24,6 +24,7 @@ module "codebuild_ci_cid-checker_mainnet" {
   privileged_mode          = true
   is_build_concurrent      = false
   specific_branch          = "main"
+  specific_envs            = { "NETWORK": "mainnet" }
 
   depends_on = [
     aws_secretsmanager_secret.github_cd_token_secret
@@ -39,6 +40,7 @@ module "codebuild_ci_cid-checker_calibration" {
   privileged_mode          = true
   is_build_concurrent      = false
   specific_branch          = "calibration"
+  specific_envs            = { "NETWORK": "calibration" }
 
   depends_on = [
     aws_secretsmanager_secret.github_cd_token_secret
@@ -54,6 +56,7 @@ module "codebuild_ci_cid-checker_wallaby" {
   privileged_mode          = true
   is_build_concurrent      = false
   specific_branch          = "wallaby"
+  specific_envs            = { "NETWORK": "wallaby" }
 
   depends_on = [
     aws_secretsmanager_secret.github_cd_token_secret
@@ -68,6 +71,7 @@ module "codebuild_cd_cid-checker_mainnet" {
   privileged_mode          = true
   is_build_concurrent      = false
   specific_branch          = "main"
+  specific_envs            = { "NETWORK": "mainnet" }
 
   depends_on = [
     aws_secretsmanager_secret.github_cd_token_secret
@@ -82,6 +86,7 @@ module "codebuild_cd_cid-checker_calibration" {
   privileged_mode          = true
   is_build_concurrent      = false
   specific_branch          = "calibration"
+  specific_envs            = { "NETWORK": "calibration" }
 
   depends_on = [
     aws_secretsmanager_secret.github_cd_token_secret
@@ -96,6 +101,7 @@ module "codebuild_cd_cid-checker_wallaby" {
   privileged_mode          = true
   is_build_concurrent      = false
   specific_branch          = "wallaby"
+  specific_envs            = { "NETWORK": "wallaby" }
 
   depends_on = [
     aws_secretsmanager_secret.github_cd_token_secret

--- a/aws/secrets_envs.tf
+++ b/aws/secrets_envs.tf
@@ -63,21 +63,21 @@ resource "aws_secretsmanager_secret" "wallaby_archive_lotus" {
   module.generator.common_tags)
 }
 
-resource "aws_secretsmanager_secret" "cid_checker_dev" {
+resource "aws_secretsmanager_secret" "cid_checker_calibration" {
   count                   = local.is_dev_envs
-  name                    = "${module.generator.prefix}-cid-checker"
+  name                    = "${module.generator.prefix}-cid-checker-calibration"
   recovery_window_in_days = 30
 
-  tags = merge({ "Name" = "${module.generator.prefix}-cid-checker" },
+  tags = merge({ "Name" = "${module.generator.prefix}-cid-checker-calibration" },
     module.generator.common_tags)
 }
 
-resource "aws_secretsmanager_secret" "cid-checker-db" {
+resource "aws_secretsmanager_secret" "cid_checker_wallaby" {
   count                   = local.is_dev_envs
-  name                    = "${module.generator.prefix}-cid-checker-db"
+  name                    = "${module.generator.prefix}-cid-checker-wallaby"
   recovery_window_in_days = 30
 
-  tags = merge({ "Name" = "${module.generator.prefix}-cid-checker-db" },
+  tags = merge({ "Name" = "${module.generator.prefix}-cid-checker-wallaby" },
     module.generator.common_tags)
 }
 

--- a/aws/tfvars/filecoin-glif-dev-apn1.tfvars
+++ b/aws/tfvars/filecoin-glif-dev-apn1.tfvars
@@ -30,7 +30,6 @@ git_configuration = [
       project_name      = "cid-checker",
       name              = "cid-checker"
       organization_name = "glifio",
-      environment       = "dev",
       description       = "CI/CD pipeline for filecoin",
       repo_name         = "cid-checker",
     }

--- a/k8s/data.tf
+++ b/k8s/data.tf
@@ -54,6 +54,11 @@ data "aws_route53_zone" "node_glif_io" {
   private_zone = false
 }
 
+data "aws_route53_zone" "filecoin_tools" {
+  name         = "filecoin.tools"
+  private_zone = false
+}
+
 data "aws_secretsmanager_secret" "calibrationapi_archive_lotus" {
   count = local.is_dev_envs
   name  = "${module.generator.prefix}-calibrationapi-archive-lotus"

--- a/k8s/data.tf
+++ b/k8s/data.tf
@@ -227,22 +227,22 @@ data "aws_secretsmanager_secret_version" "cid_checker" {
   secret_id = data.aws_secretsmanager_secret.cid_checker[0].id
 }
 
-data "aws_secretsmanager_secret" "cid_checker_dev" {
+data "aws_secretsmanager_secret" "cid_checker_calibration" {
   count = local.is_dev_envs
-  name  = "${module.generator.prefix}-cid-checker"
+  name  = "${module.generator.prefix}-cid-checker-calibration"
 }
 
-data "aws_secretsmanager_secret_version" "cid_checker_dev" {
+data "aws_secretsmanager_secret_version" "cid_checker_calibration" {
   count     = local.is_dev_envs
-  secret_id = data.aws_secretsmanager_secret.cid_checker_dev[0].id
+  secret_id = data.aws_secretsmanager_secret.cid_checker_calibration[0].id
 }
 
-data "aws_secretsmanager_secret" "cid_checker_db" {
+data "aws_secretsmanager_secret" "cid_checker_wallaby" {
   count = local.is_dev_envs
-  name  = "${module.generator.prefix}-cid-checker-db"
+  name  = "${module.generator.prefix}-cid-checker-calibration"
 }
 
-data "aws_secretsmanager_secret_version" "cid_checker_db_secret" {
+data "aws_secretsmanager_secret_version" "cid_checker_wallaby" {
   count     = local.is_dev_envs
-  secret_id = data.aws_secretsmanager_secret.cid_checker_db[0].id
+  secret_id = data.aws_secretsmanager_secret.cid_checker_calibration[0].id
 }

--- a/k8s/locals.tf
+++ b/k8s/locals.tf
@@ -53,9 +53,15 @@ locals {
       "*.${var.route53_domain}",
       "calibration.node.glif.io",
       "*.calibration.node.glif.io",
+      "calibration.filecoin.tools",
+      "*.calibration.filecoin.tools",
+      "wallaby.filecoin.tools",
+      "*.wallaby.filecoin.tools",
     ]
     filecoin-mainnet-apn1-glif-eks = [
       "*.${var.route53_domain}",
+      "filecoin.tools",
+      "*.filecoin.tools",
     ]
   }
   external_lb_certificates = local.external_lb_certificate[terraform.workspace]

--- a/k8s/modules-ingress-dev.tf
+++ b/k8s/modules-ingress-dev.tf
@@ -11,6 +11,7 @@ module "ingress-kong_cid-checker-wallaby" {
   get_rule_host                      = "wallaby.filecoin.tools"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
 }
 
 module "ingress-kong_cid-checker-wallaby-api" {
@@ -24,6 +25,7 @@ module "ingress-kong_cid-checker-wallaby-api" {
   get_rule_host                      = "wallaby.filecoin.tools"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
 }
 
 module "ingress-kong_cid-checker-wallaby-docs" {
@@ -37,6 +39,7 @@ module "ingress-kong_cid-checker-wallaby-docs" {
   get_rule_host                      = "wallaby.filecoin.tools"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
 }
 
 module "ingress-kong_cid-checker-wallaby-docs-subresources" {
@@ -50,6 +53,7 @@ module "ingress-kong_cid-checker-wallaby-docs-subresources" {
   get_rule_host                      = "wallaby.filecoin.tools"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
 }
 
 module "ingress-kong_cid-checker-alternative-domain-wallaby" {
@@ -64,6 +68,7 @@ module "ingress-kong_cid-checker-alternative-domain-wallaby" {
   get_rule_host                      = "cid.wallaby.filecoin.tools"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
 }
 
 module "ingress-kong_cid-checker-alternative-domain-wallaby-api" {
@@ -77,6 +82,7 @@ module "ingress-kong_cid-checker-alternative-domain-wallaby-api" {
   get_rule_host                      = "cid.wallaby.filecoin.tools"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
 }
 
 module "ingress-kong_cid-checker-alternative-domain-wallaby-docs" {
@@ -90,6 +96,7 @@ module "ingress-kong_cid-checker-alternative-domain-wallaby-docs" {
   get_rule_host                      = "cid.wallaby.filecoin.tools"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
 }
 
 module "ingress-kong_cid-checker-alternative-domain-wallaby-docs-subresources" {
@@ -103,6 +110,7 @@ module "ingress-kong_cid-checker-alternative-domain-wallaby-docs-subresources" {
   get_rule_host                      = "cid.wallaby.filecoin.tools"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
 }
 
 ############CID Checker Calibration#######################################
@@ -146,6 +154,7 @@ module "ingress-kong_cid-checker-calibration-docs" {
   get_rule_host                      = "calibration.filecoin.tools"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
 }
 
 module "ingress-kong_cid-checker-calibration-docs-subresources" {
@@ -159,6 +168,7 @@ module "ingress-kong_cid-checker-calibration-docs-subresources" {
   get_rule_host                      = "calibration.filecoin.tools"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
 }
 
 module "ingress-kong_cid-checker-alternative-domain-calibration" {
@@ -201,6 +211,7 @@ module "ingress-kong_cid-checker-alternative-domain-calibration-docs" {
   get_rule_host                      = "cid.calibration.filecoin.tools"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
 }
 
 module "ingress-kong_cid-checker-alternative-domain-calibration-docs-subresources" {
@@ -214,6 +225,7 @@ module "ingress-kong_cid-checker-alternative-domain-calibration-docs-subresource
   get_rule_host                      = "cid.calibration.filecoin.tools"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
 }
 
 ############calibration.node.glif.io##########################

--- a/k8s/modules-ingress-dev.tf
+++ b/k8s/modules-ingress-dev.tf
@@ -13,7 +13,7 @@ module "ingress-kong_cid-checker-wallaby" {
   is_kong_auth_header_enabled        = false
 }
 
-module "ingress-kong_cid-checker-calibrationnet-api" {
+module "ingress-kong_cid-checker-wallaby-api" {
   count                              = local.is_dev_envs
   source                             = "../modules/k8s_ingress"
   get_global_configuration           = local.make_global_configuration
@@ -26,7 +26,7 @@ module "ingress-kong_cid-checker-calibrationnet-api" {
   is_kong_auth_header_enabled        = false
 }
 
-module "ingress-kong_cid-checker-alternative-domain-calibrationnet" {
+module "ingress-kong_cid-checker-alternative-domain-wallaby" {
   count                              = local.is_dev_envs
   source                             = "../modules/k8s_ingress"
   get_global_configuration           = local.make_global_configuration
@@ -40,7 +40,7 @@ module "ingress-kong_cid-checker-alternative-domain-calibrationnet" {
   is_kong_auth_header_enabled        = false
 }
 
-module "ingress-kong_cid-checker-alternative-domain-calibrationnet-api" {
+module "ingress-kong_cid-checker-alternative-domain-wallaby-api" {
   count                              = local.is_dev_envs
   source                             = "../modules/k8s_ingress"
   get_global_configuration           = local.make_global_configuration
@@ -54,7 +54,7 @@ module "ingress-kong_cid-checker-alternative-domain-calibrationnet-api" {
 }
 
 ############CID Checker Calibration#######################################
-module "ingress-kong_cid-checker-calibrationnet" {
+module "ingress-kong_cid-checker-calibration" {
   count                              = local.is_dev_envs
   source                             = "../modules/k8s_ingress"
   get_global_configuration           = local.make_global_configuration
@@ -69,7 +69,7 @@ module "ingress-kong_cid-checker-calibrationnet" {
   is_kong_transformer_header_enabled = false
 }
 
-module "ingress-kong_cid-checker-calibrationnet-api" {
+module "ingress-kong_cid-checker-calibration-api" {
   count                              = local.is_dev_envs
   source                             = "../modules/k8s_ingress"
   get_global_configuration           = local.make_global_configuration
@@ -83,7 +83,7 @@ module "ingress-kong_cid-checker-calibrationnet-api" {
   is_kong_transformer_header_enabled = false
 }
 
-module "ingress-kong_cid-checker-alternative-domain-calibrationnet" {
+module "ingress-kong_cid-checker-alternative-domain-calibration" {
   count                              = local.is_dev_envs
   source                             = "../modules/k8s_ingress"
   get_global_configuration           = local.make_global_configuration
@@ -98,7 +98,7 @@ module "ingress-kong_cid-checker-alternative-domain-calibrationnet" {
   is_kong_transformer_header_enabled = false
 }
 
-module "ingress-kong_cid-checker-alternative-domain-calibrationnet-api" {
+module "ingress-kong_cid-checker-alternative-domain-calibration-api" {
   count                              = local.is_dev_envs
   source                             = "../modules/k8s_ingress"
   get_global_configuration           = local.make_global_configuration

--- a/k8s/modules-ingress-dev.tf
+++ b/k8s/modules-ingress-dev.tf
@@ -26,6 +26,32 @@ module "ingress-kong_cid-checker-wallaby-api" {
   is_kong_auth_header_enabled        = false
 }
 
+module "ingress-kong_cid-checker-wallaby-docs" {
+  count                              = local.is_dev_envs
+  source                             = "../modules/k8s_ingress"
+  get_global_configuration           = local.make_global_configuration
+  get_ingress_http_path              = "/docs"
+  get_ingress_backend_service_name   = "cid-checker-wallaby-backend" // the "-service" string will be added automatically
+  get_ingress_backend_service_port   = 3000
+  get_ingress_namespace              = "default"
+  get_rule_host                      = "wallaby.filecoin.tools"
+  type_lb_scheme                     = "external"
+  is_kong_auth_header_enabled        = false
+}
+
+module "ingress-kong_cid-checker-wallaby-docs-subresources" {
+  count                              = local.is_dev_envs
+  source                             = "../modules/k8s_ingress"
+  get_global_configuration           = local.make_global_configuration
+  get_ingress_http_path              = "/docs/(.*)"
+  get_ingress_backend_service_name   = "cid-checker-wallaby-backend" // the "-service" string will be added automatically
+  get_ingress_backend_service_port   = 3000
+  get_ingress_namespace              = "default"
+  get_rule_host                      = "wallaby.filecoin.tools"
+  type_lb_scheme                     = "external"
+  is_kong_auth_header_enabled        = false
+}
+
 module "ingress-kong_cid-checker-alternative-domain-wallaby" {
   count                              = local.is_dev_envs
   source                             = "../modules/k8s_ingress"
@@ -45,6 +71,32 @@ module "ingress-kong_cid-checker-alternative-domain-wallaby-api" {
   source                             = "../modules/k8s_ingress"
   get_global_configuration           = local.make_global_configuration
   get_ingress_http_path              = "/api/(.*)"
+  get_ingress_backend_service_name   = "cid-checker-wallaby-backend" // the "-service" string will be added automatically
+  get_ingress_backend_service_port   = 3000
+  get_ingress_namespace              = "default"
+  get_rule_host                      = "cid.wallaby.filecoin.tools"
+  type_lb_scheme                     = "external"
+  is_kong_auth_header_enabled        = false
+}
+
+module "ingress-kong_cid-checker-alternative-domain-wallaby-docs" {
+  count                              = local.is_dev_envs
+  source                             = "../modules/k8s_ingress"
+  get_global_configuration           = local.make_global_configuration
+  get_ingress_http_path              = "/docs"
+  get_ingress_backend_service_name   = "cid-checker-wallaby-backend" // the "-service" string will be added automatically
+  get_ingress_backend_service_port   = 3000
+  get_ingress_namespace              = "default"
+  get_rule_host                      = "cid.wallaby.filecoin.tools"
+  type_lb_scheme                     = "external"
+  is_kong_auth_header_enabled        = false
+}
+
+module "ingress-kong_cid-checker-alternative-domain-wallaby-docs-subresources" {
+  count                              = local.is_dev_envs
+  source                             = "../modules/k8s_ingress"
+  get_global_configuration           = local.make_global_configuration
+  get_ingress_http_path              = "/docs/(.*)"
   get_ingress_backend_service_name   = "cid-checker-wallaby-backend" // the "-service" string will be added automatically
   get_ingress_backend_service_port   = 3000
   get_ingress_namespace              = "default"
@@ -83,6 +135,32 @@ module "ingress-kong_cid-checker-calibration-api" {
   is_kong_transformer_header_enabled = false
 }
 
+module "ingress-kong_cid-checker-calibration-docs" {
+  count                              = local.is_dev_envs
+  source                             = "../modules/k8s_ingress"
+  get_global_configuration           = local.make_global_configuration
+  get_ingress_http_path              = "/docs"
+  get_ingress_backend_service_name   = "cid-checker-calibration-backend" // the "-service" string will be added automatically
+  get_ingress_backend_service_port   = 3000
+  get_ingress_namespace              = "default"
+  get_rule_host                      = "calibration.filecoin.tools"
+  type_lb_scheme                     = "external"
+  is_kong_auth_header_enabled        = false
+}
+
+module "ingress-kong_cid-checker-calibration-docs-subresources" {
+  count                              = local.is_dev_envs
+  source                             = "../modules/k8s_ingress"
+  get_global_configuration           = local.make_global_configuration
+  get_ingress_http_path              = "/docs/(.*)"
+  get_ingress_backend_service_name   = "cid-checker-calibration-backend" // the "-service" string will be added automatically
+  get_ingress_backend_service_port   = 3000
+  get_ingress_namespace              = "default"
+  get_rule_host                      = "calibration.filecoin.tools"
+  type_lb_scheme                     = "external"
+  is_kong_auth_header_enabled        = false
+}
+
 module "ingress-kong_cid-checker-alternative-domain-calibration" {
   count                              = local.is_dev_envs
   source                             = "../modules/k8s_ingress"
@@ -110,6 +188,32 @@ module "ingress-kong_cid-checker-alternative-domain-calibration-api" {
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
   is_kong_transformer_header_enabled = false
+}
+
+module "ingress-kong_cid-checker-alternative-domain-calibration-docs" {
+  count                              = local.is_dev_envs
+  source                             = "../modules/k8s_ingress"
+  get_global_configuration           = local.make_global_configuration
+  get_ingress_http_path              = "/docs"
+  get_ingress_backend_service_name   = "cid-checker-calibration-backend" // the "-service" string will be added automatically
+  get_ingress_backend_service_port   = 3000
+  get_ingress_namespace              = "default"
+  get_rule_host                      = "cid.calibration.filecoin.tools"
+  type_lb_scheme                     = "external"
+  is_kong_auth_header_enabled        = false
+}
+
+module "ingress-kong_cid-checker-alternative-domain-calibration-docs-subresources" {
+  count                              = local.is_dev_envs
+  source                             = "../modules/k8s_ingress"
+  get_global_configuration           = local.make_global_configuration
+  get_ingress_http_path              = "/docs/(.*)"
+  get_ingress_backend_service_name   = "cid-checker-calibration-backend" // the "-service" string will be added automatically
+  get_ingress_backend_service_port   = 3000
+  get_ingress_namespace              = "default"
+  get_rule_host                      = "cid.calibration.filecoin.tools"
+  type_lb_scheme                     = "external"
+  is_kong_auth_header_enabled        = false
 }
 
 ############calibration.node.glif.io##########################

--- a/k8s/modules-ingress-dev.tf
+++ b/k8s/modules-ingress-dev.tf
@@ -1,14 +1,14 @@
-############CID Checker#######################################
-module "ingress-kong_cid-checker-calibrationnet" {
+############CID Checker Wallaby#######################################
+module "ingress-kong_cid-checker-wallaby" {
   count                              = local.is_dev_envs
   source                             = "../modules/k8s_ingress"
   get_global_configuration           = local.make_global_configuration
   get_ingress_http_path              = "/"
   get_ingress_pathType              = "Prefix"
-  get_ingress_backend_service_name   = "cid-checker-frontend" // the "-service" string will be added automatically
+  get_ingress_backend_service_name   = "cid-checker-wallaby-frontend" // the "-service" string will be added automatically
   get_ingress_backend_service_port   = 80
   get_ingress_namespace              = "default" 
-  get_rule_host                      = "cid.calibration.node.glif.io"
+  get_rule_host                      = "wallaby.filecoin.tools"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
 }
@@ -18,37 +18,92 @@ module "ingress-kong_cid-checker-calibrationnet-api" {
   source                             = "../modules/k8s_ingress"
   get_global_configuration           = local.make_global_configuration
   get_ingress_http_path              = "/api/(.*)"
-  get_ingress_backend_service_name   = "cid-checker-backend" // the "-service" string will be added automatically
+  get_ingress_backend_service_name   = "cid-checker-wallaby-backend" // the "-service" string will be added automatically
   get_ingress_backend_service_port   = 3000
   get_ingress_namespace              = "default"
-  get_rule_host                      = "cid.calibration.node.glif.io"
+  get_rule_host                      = "wallaby.filecoin.tools"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
 }
 
-module "ingress-kong_cid-checker-another-calibrationnet" {
+module "ingress-kong_cid-checker-alternative-domain-calibrationnet" {
   count                              = local.is_dev_envs
   source                             = "../modules/k8s_ingress"
   get_global_configuration           = local.make_global_configuration
   get_ingress_http_path              = "/"
   get_ingress_pathType              = "Prefix"
-  get_ingress_backend_service_name   = "cid-checker-frontend" // the "-service" string will be added automatically
+  get_ingress_backend_service_name   = "cid-checker-wallaby-frontend" // the "-service" string will be added automatically
   get_ingress_backend_service_port   = 80
   get_ingress_namespace              = "default"
-  get_rule_host                      = "cid-another.calibration.node.glif.io"
+  get_rule_host                      = "cid.wallaby.filecoin.tools"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
 }
 
-module "ingress-kong_cid-checker-another-calibrationnet-api" {
+module "ingress-kong_cid-checker-alternative-domain-calibrationnet-api" {
   count                              = local.is_dev_envs
   source                             = "../modules/k8s_ingress"
   get_global_configuration           = local.make_global_configuration
   get_ingress_http_path              = "/api/(.*)"
-  get_ingress_backend_service_name   = "cid-checker-backend" // the "-service" string will be added automatically
+  get_ingress_backend_service_name   = "cid-checker-wallaby-backend" // the "-service" string will be added automatically
   get_ingress_backend_service_port   = 3000
   get_ingress_namespace              = "default"
-  get_rule_host                      = "cid-another.calibration.node.glif.io"
+  get_rule_host                      = "cid.wallaby.filecoin.tools"
+  type_lb_scheme                     = "external"
+  is_kong_auth_header_enabled        = false
+}
+
+############CID Checker Calibration#######################################
+module "ingress-kong_cid-checker-calibrationnet" {
+  count                              = local.is_dev_envs
+  source                             = "../modules/k8s_ingress"
+  get_global_configuration           = local.make_global_configuration
+  get_ingress_http_path              = "/"
+  get_ingress_pathType              = "Prefix"
+  get_ingress_backend_service_name   = "cid-checker-calibration-frontend" // the "-service" string will be added automatically
+  get_ingress_backend_service_port   = 80
+  get_ingress_namespace              = "default" 
+  get_rule_host                      = "calibration.filecoin.tools"
+  type_lb_scheme                     = "external"
+  is_kong_auth_header_enabled        = false
+}
+
+module "ingress-kong_cid-checker-calibrationnet-api" {
+  count                              = local.is_dev_envs
+  source                             = "../modules/k8s_ingress"
+  get_global_configuration           = local.make_global_configuration
+  get_ingress_http_path              = "/api/(.*)"
+  get_ingress_backend_service_name   = "cid-checker-calibration-backend" // the "-service" string will be added automatically
+  get_ingress_backend_service_port   = 3000
+  get_ingress_namespace              = "default"
+  get_rule_host                      = "calibration.filecoin.tools"
+  type_lb_scheme                     = "external"
+  is_kong_auth_header_enabled        = false
+}
+
+module "ingress-kong_cid-checker-alternative-domain-calibrationnet" {
+  count                              = local.is_dev_envs
+  source                             = "../modules/k8s_ingress"
+  get_global_configuration           = local.make_global_configuration
+  get_ingress_http_path              = "/"
+  get_ingress_pathType              = "Prefix"
+  get_ingress_backend_service_name   = "cid-checker-calibration-frontend" // the "-service" string will be added automatically
+  get_ingress_backend_service_port   = 80
+  get_ingress_namespace              = "default"
+  get_rule_host                      = "cid.calibration.filecoin.tools"
+  type_lb_scheme                     = "external"
+  is_kong_auth_header_enabled        = false
+}
+
+module "ingress-kong_cid-checker-alternative-domain-calibrationnet-api" {
+  count                              = local.is_dev_envs
+  source                             = "../modules/k8s_ingress"
+  get_global_configuration           = local.make_global_configuration
+  get_ingress_http_path              = "/api/(.*)"
+  get_ingress_backend_service_name   = "cid-checker-calibration-backend" // the "-service" string will be added automatically
+  get_ingress_backend_service_port   = 3000
+  get_ingress_namespace              = "default"
+  get_rule_host                      = "cid.calibration.filecoin.tools"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
 }

--- a/k8s/modules-ingress-mainnet.tf
+++ b/k8s/modules-ingress-mainnet.tf
@@ -8,7 +8,7 @@ module "ingress-kong_cid-checker-mainnet" {
   get_ingress_backend_service_name   = "cid-checker-frontend" // the "-service" string will be added automatically
   get_ingress_backend_service_port   = 80
   get_ingress_namespace              = "default" 
-  get_rule_host                      = "cid.node.glif.io"
+  get_rule_host                      = "filecoin.tools"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
 }
@@ -21,12 +21,12 @@ module "ingress-kong_cid-checker-mainnet-api" {
   get_ingress_backend_service_name   = "cid-checker-backend" // the "-service" string will be added automatically
   get_ingress_backend_service_port   = 3000
   get_ingress_namespace              = "default"
-  get_rule_host                      = "cid.node.glif.io"
+  get_rule_host                      = "filecoin.tools"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
 }
 
-module "ingress-kong_cid-checker-another-mainnet" {
+module "ingress-kong_cid-checker-alternative-domain-mainnet" {
   count                              = local.is_mainnet_envs
   source                             = "../modules/k8s_ingress"
   get_global_configuration           = local.make_global_configuration
@@ -35,12 +35,12 @@ module "ingress-kong_cid-checker-another-mainnet" {
   get_ingress_backend_service_name   = "cid-checker-frontend" // the "-service" string will be added automatically
   get_ingress_backend_service_port   = 80
   get_ingress_namespace              = "default"
-  get_rule_host                      = "cid-another.node.glif.io"
+  get_rule_host                      = "cid.filecoin.tools"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
 }
 
-module "ingress-kong_cid-checker-another-mainnet-api" {
+module "ingress-kong_cid-checker-alternative-domain-mainnet-api" {
   count                              = local.is_mainnet_envs
   source                             = "../modules/k8s_ingress"
   get_global_configuration           = local.make_global_configuration
@@ -48,7 +48,7 @@ module "ingress-kong_cid-checker-another-mainnet-api" {
   get_ingress_backend_service_name   = "cid-checker-backend" // the "-service" string will be added automatically
   get_ingress_backend_service_port   = 3000
   get_ingress_namespace              = "default"
-  get_rule_host                      = "cid-another.node.glif.io"
+  get_rule_host                      = "cid.filecoin.tools"
   type_lb_scheme                     = "external"
   is_kong_auth_header_enabled        = false
 }

--- a/k8s/modules-ingress-mainnet.tf
+++ b/k8s/modules-ingress-mainnet.tf
@@ -28,6 +28,34 @@ module "ingress-kong_cid-checker-mainnet-api" {
   is_kong_transformer_header_enabled = false
 }
 
+module "ingress-kong_cid-checker-mainnet-docs" {
+  count                              = local.is_mainnet_envs
+  source                             = "../modules/k8s_ingress"
+  get_global_configuration           = local.make_global_configuration
+  get_ingress_http_path              = "/docs"
+  get_ingress_backend_service_name   = "cid-checker-mainnet-backend" // the "-service" string will be added automatically
+  get_ingress_backend_service_port   = 3000
+  get_ingress_namespace              = "default"
+  get_rule_host                      = "filecoin.tools"
+  type_lb_scheme                     = "external"
+  is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
+}
+
+module "ingress-kong_cid-checker-mainnet-docs-subresources" {
+  count                              = local.is_mainnet_envs
+  source                             = "../modules/k8s_ingress"
+  get_global_configuration           = local.make_global_configuration
+  get_ingress_http_path              = "/docs/(.*)"
+  get_ingress_backend_service_name   = "cid-checker-mainnet-backend" // the "-service" string will be added automatically
+  get_ingress_backend_service_port   = 3000
+  get_ingress_namespace              = "default"
+  get_rule_host                      = "filecoin.tools"
+  type_lb_scheme                     = "external"
+  is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
+}
+
 module "ingress-kong_cid-checker-alternative-domain-mainnet" {
   count                              = local.is_mainnet_envs
   source                             = "../modules/k8s_ingress"
@@ -48,6 +76,34 @@ module "ingress-kong_cid-checker-alternative-domain-mainnet-api" {
   source                             = "../modules/k8s_ingress"
   get_global_configuration           = local.make_global_configuration
   get_ingress_http_path              = "/api/(.*)"
+  get_ingress_backend_service_name   = "cid-checker-mainnet-backend" // the "-service" string will be added automatically
+  get_ingress_backend_service_port   = 3000
+  get_ingress_namespace              = "default"
+  get_rule_host                      = "cid.filecoin.tools"
+  type_lb_scheme                     = "external"
+  is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
+}
+
+module "ingress-kong_cid-checker-alternative-domain-mainnet-docs" {
+  count                              = local.is_mainnet_envs
+  source                             = "../modules/k8s_ingress"
+  get_global_configuration           = local.make_global_configuration
+  get_ingress_http_path              = "/docs"
+  get_ingress_backend_service_name   = "cid-checker-mainnet-backend" // the "-service" string will be added automatically
+  get_ingress_backend_service_port   = 3000
+  get_ingress_namespace              = "default"
+  get_rule_host                      = "cid.filecoin.tools"
+  type_lb_scheme                     = "external"
+  is_kong_auth_header_enabled        = false
+  is_kong_transformer_header_enabled = false
+}
+
+module "ingress-kong_cid-checker-alternative-domain-mainnet-docs-subresources" {
+  count                              = local.is_mainnet_envs
+  source                             = "../modules/k8s_ingress"
+  get_global_configuration           = local.make_global_configuration
+  get_ingress_http_path              = "/docs/(.*)"
   get_ingress_backend_service_name   = "cid-checker-mainnet-backend" // the "-service" string will be added automatically
   get_ingress_backend_service_port   = 3000
   get_ingress_namespace              = "default"

--- a/k8s/modules-ingress-mainnet.tf
+++ b/k8s/modules-ingress-mainnet.tf
@@ -5,7 +5,7 @@ module "ingress-kong_cid-checker-mainnet" {
   get_global_configuration           = local.make_global_configuration
   get_ingress_http_path              = "/"
   get_ingress_pathType              = "Prefix"
-  get_ingress_backend_service_name   = "cid-checker-frontend" // the "-service" string will be added automatically
+  get_ingress_backend_service_name   = "cid-checker-mainnet-frontend" // the "-service" string will be added automatically
   get_ingress_backend_service_port   = 80
   get_ingress_namespace              = "default" 
   get_rule_host                      = "filecoin.tools"
@@ -19,7 +19,7 @@ module "ingress-kong_cid-checker-mainnet-api" {
   source                             = "../modules/k8s_ingress"
   get_global_configuration           = local.make_global_configuration
   get_ingress_http_path              = "/api/(.*)"
-  get_ingress_backend_service_name   = "cid-checker-backend" // the "-service" string will be added automatically
+  get_ingress_backend_service_name   = "cid-checker-mainnet-backend" // the "-service" string will be added automatically
   get_ingress_backend_service_port   = 3000
   get_ingress_namespace              = "default"
   get_rule_host                      = "filecoin.tools"
@@ -34,7 +34,7 @@ module "ingress-kong_cid-checker-alternative-domain-mainnet" {
   get_global_configuration           = local.make_global_configuration
   get_ingress_http_path              = "/"
   get_ingress_pathType              = "Prefix"
-  get_ingress_backend_service_name   = "cid-checker-frontend" // the "-service" string will be added automatically
+  get_ingress_backend_service_name   = "cid-checker-mainnet-frontend" // the "-service" string will be added automatically
   get_ingress_backend_service_port   = 80
   get_ingress_namespace              = "default"
   get_rule_host                      = "cid.filecoin.tools"
@@ -48,7 +48,7 @@ module "ingress-kong_cid-checker-alternative-domain-mainnet-api" {
   source                             = "../modules/k8s_ingress"
   get_global_configuration           = local.make_global_configuration
   get_ingress_http_path              = "/api/(.*)"
-  get_ingress_backend_service_name   = "cid-checker-backend" // the "-service" string will be added automatically
+  get_ingress_backend_service_name   = "cid-checker-mainnet-backend" // the "-service" string will be added automatically
   get_ingress_backend_service_port   = 3000
   get_ingress_namespace              = "default"
   get_rule_host                      = "cid.filecoin.tools"

--- a/k8s/route53.tf
+++ b/k8s/route53.tf
@@ -23,20 +23,20 @@ resource "aws_route53_record" "dev_nlb_ingress_internal" {
 }
 
 # CID CHECKER Calibrationnet
-resource "aws_route53_record" "cid_nlb_ingress_external_calibration" {
+resource "aws_route53_record" "filecoin_tools_nlb_ingress_external_calibration" {
   count           = local.is_dev_envs
-  zone_id         = data.aws_route53_zone.node_glif_io.zone_id
-  name            = "cid.calibration.node.glif.io"
+  zone_id         = data.aws_route53_zone.filecoin_tools.zone_id
+  name            = "calibration.filecoin.tools"
   allow_overwrite = true
   type            = "CNAME"
   ttl             = "60"
   records         = [data.aws_lb.kong_external.dns_name]
 }
 
-resource "aws_route53_record" "cid_another_nlb_ingress_external_calibration" {
+resource "aws_route53_record" "cid_filecoin_tools_nlb_ingress_external_calibration" {
   count           = local.is_dev_envs
-  zone_id         = data.aws_route53_zone.node_glif_io.zone_id
-  name            = "cid-another.calibration.node.glif.io"
+  zone_id         = data.aws_route53_zone.filecoin_tools.zone_id
+  name            = "cid.calibration.filecoin.tools"
   allow_overwrite = true
   type            = "CNAME"
   ttl             = "60"
@@ -44,20 +44,20 @@ resource "aws_route53_record" "cid_another_nlb_ingress_external_calibration" {
 }
 
 # CID CHECKER Mainnet
-resource "aws_route53_record" "cid_nlb_ingress_external_mainnet" {
+resource "aws_route53_record" "filecoin_tools_nlb_ingress_external_mainnet" {
   count           = local.is_mainnet_envs
-  zone_id         = data.aws_route53_zone.node_glif_io.zone_id
-  name            = "cid.node.glif.io"
+  zone_id         = data.aws_route53_zone.filecoin_tools.zone_id
+  name            = "filecoin.tools"
   allow_overwrite = true
   type            = "CNAME"
   ttl             = "60"
   records         = [data.aws_lb.kong_external.dns_name]
 }
 
-resource "aws_route53_record" "cid_another_nlb_ingress_external_mainnet" {
+resource "aws_route53_record" "cid_filecoin_tools_nlb_ingress_external_mainnet" {
   count           = local.is_mainnet_envs
-  zone_id         = data.aws_route53_zone.node_glif_io.zone_id
-  name            = "cid-another.node.glif.io"
+  zone_id         = data.aws_route53_zone.filecoin_tools.zone_id
+  name            = "cid.filecoin.tools"
   allow_overwrite = true
   type            = "CNAME"
   ttl             = "60"

--- a/k8s/route53.tf
+++ b/k8s/route53.tf
@@ -22,7 +22,28 @@ resource "aws_route53_record" "dev_nlb_ingress_internal" {
   records         = [data.aws_lb.kong_internal.dns_name]
 }
 
-# CID CHECKER Calibrationnet
+# CID CHECKER Wallaby
+resource "aws_route53_record" "filecoin_tools_nlb_ingress_external_wallaby" {
+  count           = local.is_dev_envs
+  zone_id         = data.aws_route53_zone.filecoin_tools.zone_id
+  name            = "wallaby.filecoin.tools"
+  allow_overwrite = true
+  type            = "CNAME"
+  ttl             = "60"
+  records         = [data.aws_lb.kong_external.dns_name]
+}
+
+resource "aws_route53_record" "cid_filecoin_tools_nlb_ingress_external_wallaby" {
+  count           = local.is_dev_envs
+  zone_id         = data.aws_route53_zone.filecoin_tools.zone_id
+  name            = "cid.wallaby.filecoin.tools"
+  allow_overwrite = true
+  type            = "CNAME"
+  ttl             = "60"
+  records         = [data.aws_lb.kong_external.dns_name]
+}
+
+# CID CHECKER Calibration
 resource "aws_route53_record" "filecoin_tools_nlb_ingress_external_calibration" {
   count           = local.is_dev_envs
   zone_id         = data.aws_route53_zone.filecoin_tools.zone_id

--- a/k8s/route53.tf
+++ b/k8s/route53.tf
@@ -70,9 +70,13 @@ resource "aws_route53_record" "filecoin_tools_nlb_ingress_external_mainnet" {
   zone_id         = data.aws_route53_zone.filecoin_tools.zone_id
   name            = "filecoin.tools"
   allow_overwrite = true
-  type            = "CNAME"
-  ttl             = "60"
-  records         = [data.aws_lb.kong_external.dns_name]
+  type            = "A"
+
+  alias {
+    name                   = data.aws_lb.kong_external.dns_name
+    zone_id                = data.aws_lb.kong_external.zone_id
+    evaluate_target_health = true
+  }
 }
 
 resource "aws_route53_record" "cid_filecoin_tools_nlb_ingress_external_mainnet" {

--- a/k8s/secrets.tf
+++ b/k8s/secrets.tf
@@ -237,6 +237,18 @@ resource "kubernetes_secret_v1" "cid_checker_secret" {
   }
 }
 
+resource "kubernetes_secret_v1" "cid_checker_mainnet_secret" {
+  count = local.is_mainnet_envs
+  metadata {
+    name      = "cid-checker-mainnet-secret"
+    namespace = "default"
+  }
+  data = {
+    dbUsername = lookup(jsondecode(data.aws_secretsmanager_secret_version.cid_checker[0].secret_string), "dbUsername", null)
+    dbPassword = lookup(jsondecode(data.aws_secretsmanager_secret_version.cid_checker[0].secret_string), "dbPassword", null)
+  }
+}
+
 resource "kubernetes_secret_v1" "cid_checker_calibration_secret" {
   count = local.is_dev_envs
   metadata {

--- a/k8s/secrets.tf
+++ b/k8s/secrets.tf
@@ -237,26 +237,26 @@ resource "kubernetes_secret_v1" "cid_checker_secret" {
   }
 }
 
-resource "kubernetes_secret_v1" "cid_checker_secret_dev" {
+resource "kubernetes_secret_v1" "cid_checker_calibration_secret" {
   count = local.is_dev_envs
   metadata {
-    name      = "cid-checker-secret"
-    namespace = kubernetes_namespace_v1.network.metadata[0].name
-  }
-  data = {
-    mongoURL = lookup(jsondecode(data.aws_secretsmanager_secret_version.cid_checker_dev[0].secret_string), "mongoURL", null)
-  }
-}
-
-
-resource "kubernetes_secret_v1" "cid_checker_db_secret" {
-  count = local.is_dev_envs
-  metadata {
-    name      = "cid-checker-db-secret"
+    name      = "cid-checker-calibration-secret"
     namespace = "default"
   }
   data = {
-    dbUsername = lookup(jsondecode(data.aws_secretsmanager_secret_version.cid_checker_db_secret[0].secret_string), "dbUsername", null)
-    dbPassword = lookup(jsondecode(data.aws_secretsmanager_secret_version.cid_checker_db_secret[0].secret_string), "dbPassword", null)
+    dbUsername = lookup(jsondecode(data.aws_secretsmanager_secret_version.cid_checker_calibration[0].secret_string), "dbUsername", null)
+    dbPassword = lookup(jsondecode(data.aws_secretsmanager_secret_version.cid_checker_calibration[0].secret_string), "dbPassword", null)
+  }
+}
+
+resource "kubernetes_secret_v1" "cid_checker_wallaby_secret" {
+  count = local.is_dev_envs
+  metadata {
+    name      = "cid-checker-wallaby-secret"
+    namespace = "default"
+  }
+  data = {
+    dbUsername = lookup(jsondecode(data.aws_secretsmanager_secret_version.cid_checker_wallaby[0].secret_string), "dbUsername", null)
+    dbPassword = lookup(jsondecode(data.aws_secretsmanager_secret_version.cid_checker_wallaby[0].secret_string), "dbPassword", null)
   }
 }

--- a/modules/codebuild/codebuild.tf
+++ b/modules/codebuild/codebuild.tf
@@ -25,6 +25,14 @@ resource "aws_codebuild_project" "codebuild" {
         value = environment_variable.value
       }
     }
+
+    dynamic "environment_variable" {
+      for_each = var.specific_envs
+      content {
+        name  = environment_variable.key
+        value = environment_variable.value
+      }
+    }
   }
   source {
     type = "GITHUB"

--- a/modules/codebuild/locals.tf
+++ b/modules/codebuild/locals.tf
@@ -27,7 +27,7 @@ locals {
   is_build_only          = var.is_build_only ? 1 : 0
   is_deploy_only         = !var.is_build_only ? 1 : 0
 
-  codebuild_name              = "${module.generator.prefix}-${local.git_config[0].project_name}-codebuild"
+  codebuild_name              = "${module.generator.prefix}-${local.git_config[0].project_name}-codebuild-${random_string.uid.result}"
   make_codebuild_current_name = var.is_build_only ? "${local.codebuild_name}-build" : "${local.codebuild_name}-deploy"
   make_codebuild_description  = var.is_build_only ? "${local.git_config[0].description}-build" : "${local.git_config[0].description}-deploy"
   github_token                = lookup(jsondecode(data.aws_secretsmanager_secret_version.git_credentials.secret_string), "github_token", null)

--- a/modules/codebuild/variables.tf
+++ b/modules/codebuild/variables.tf
@@ -54,3 +54,8 @@ variable "specific_branch" {
   type    = string
   default = null
 }
+
+variable "specific_envs" {
+  type    = map
+  default = {}
+}


### PR DESCRIPTION
Before it was not possible because every new codebuild name would be the same as the other one in the cluster

Also adding CID Checker Wallabynet here and renaming Calibration wallaby