### PR TITLE
[feat] - create cronjob for chain_snap as module

### DIFF
--- a/k8s/modules_chain_snapshots_dev.tf
+++ b/k8s/modules_chain_snapshots_dev.tf
@@ -1,0 +1,8 @@
+module "calibrationapi_chain_snapshot" {
+  count     = local.is_dev_envs
+  source    = "../modules/cronjob_lotus_chain_snapshots"
+  sts_name  = "calibrationapi"
+  namespace = kubernetes_namespace_v1.network.metadata[0].name
+  git_repo  = "git@gist.github.com:95da15b014ffc3b5a170485001f46abd.git"
+  schedule  = "0 0 * * *"
+}

--- a/modules/cronjob_lotus_chain_snapshots/configs/creator/creator.sh
+++ b/modules/cronjob_lotus_chain_snapshots/configs/creator/creator.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+#TODO: add test of snapshot and some logic for saving more than 1 snapshot
+#TODO: we don't catch SIGTERM and logic in the container will continue, we need to handle this somehow
+
+set -eou pipefail
+
+timestamp() {
+    date '+%F_%T'
+}
+
+NAMESPACE='${namespace}'
+BLOCKS_TO_EXPORT='${blocks_to_export}'
+POD='${pod}'
+CONTAINER='filecoin'
+CONTAINER='${container}'
+CUR_SNAP='/data/ipfs/lotus-current.car'
+NEW_SNAP='/data/ipfs/lotus-new.car'
+SHELL='${shell}'
+
+run_in_container() {
+    kubectl exec $POD -c $CONTAINER -n $NAMESPACE -- $SHELL -c "$1"
+}
+
+
+if [ "$BLOCKS_TO_EXPORT" -lt 900 ]; then
+    echo "$(timestamp) - ERROR - BLOCKS_TO_EXPORT variable should be" \
+        "greater then 900 due to recent-stateroots limitation"
+    exit 1
+fi
+
+command='lotus chain list --count 1 --format "<height>"'
+current_block=$(run_in_container "$command")
+echo "$(timestamp) get current block height is $current_block, found by '$command'"
+command="lotus chain export --tipset @$current_block --recent-stateroots $BLOCKS_TO_EXPORT \
+    --skip-old-msgs $NEW_SNAP"
+echo "$(timestamp) started lotus snapshot export for $BLOCKS_TO_EXPORT blocks via '$command'"
+run_in_container "$command"
+echo "$(timestamp) finished lotus snapshot export for $BLOCKS_TO_EXPORT blocks via '$command'"
+command="mv $NEW_SNAP $CUR_SNAP"
+echo "$(timestamp) moving new on old chian_snap via $command"
+run_in_container "$command"

--- a/modules/cronjob_lotus_chain_snapshots/configs/gitter/gitter.sh
+++ b/modules/cronjob_lotus_chain_snapshots/configs/gitter/gitter.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# TODO: built our own container with tools like kubectl, git, whatever else
+#TODO: we don't catch SIGTERM and logic in the container will continue, we need to handle this somehow
+
+set -eou pipefail
+
+timestamp() {
+    date '+%F_%T'
+}
+
+NAMESPACE='${namespace}'
+POD='${pod}'
+CONTAINER='${container}'
+FILE_STORE_SNAP_NAME='${file_to_store_id}'
+SHELL='${shell}'
+REPO='${git_repo}'
+AUTHOR_NAME='${git_author}'
+AUTHOR_EMAIL='${git_email}'
+
+run_in_container() {
+    kubectl exec $POD -c $CONTAINER -n $NAMESPACE -- $SHELL -c "$1"
+}
+
+command="if [ -f $FILE_STORE_SNAP_NAME ]; then cat $FILE_STORE_SNAP_NAME; else exit 1; fi;"
+echo "$(timestamp) checking that ipfs_id in file exist via '$command'"
+ipfs_id=$(run_in_container "$command")
+echo "$(timestamp) ipfs_id is $ipfs_id"
+
+echo "$(timestamp) installing git and ssh-keyscan from openssh-client"
+apt update 1>/dev/null 2>&1 -y && apt install git openssh-client -y 1>/dev/null 2>&1
+
+echo "$(timestamp) fetching gist.github.com SSH keys"
+# TODO: consider use -o UserKnownHostsFile in the ssh command
+mkdir -p /root/.ssh
+ssh-keyscan -t rsa gist.github.com >> /root/.ssh/known_hosts
+echo "$(timestamp) cloning repo $REPO"
+git clone "$REPO" /tmp/snapshots
+echo "$(timestamp) adding ipfs_id data"
+echo "$ipfs_id" > /tmp/snapshots/snapshot.log
+echo "$(timestamp) going to /tmp/snapshots"
+cd /tmp/snapshots &&
+echo "$(timestamp) configuring git"
+git config user.name "$AUTHOR_NAME"
+git config user.email "$AUTHOR_EMAIL"
+echo "$(timestamp) committing data"
+git commit --allow-empty -a -m "new export"
+echo "$(timestamp) pushing data..."
+git push

--- a/modules/cronjob_lotus_chain_snapshots/configs/sharer/sharer.sh
+++ b/modules/cronjob_lotus_chain_snapshots/configs/sharer/sharer.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+#TODO: we don't catch SIGTERM and logic in the container will continue, we need to handle this somehow
+
+set -eou pipefail
+
+timestamp() {
+    date '+%F_%T'
+}
+
+NAMESPACE='${namespace}'
+POD='${pod}'
+CONTAINER='${container}'
+CUR_SNAP='${cur_snap}'
+FILE_STORE_SNAP_NAME='${file_to_store_id}'
+SHELL='${shell}'
+
+run_in_container() {
+    kubectl exec $POD -c $CONTAINER -n $NAMESPACE -- $SHELL -c "$1"
+}
+
+command="[ -s $CUR_SNAP ]"
+echo "$(timestamp) checking that chain_snap exist via '$command'"
+run_in_container "$command"
+
+command='ipfs pin ls --quiet --type recursive | xargs ipfs pin rm && ipfs repo gc --silent'
+echo "$(timestamp) clean up old chain snapshot from ipfs via '$command'"
+run_in_container "$command"
+
+command="ipfs add $CUR_SNAP --quiet"
+echo "$(timestamp) add chain_snap to ipfs via '$command'"
+run_in_container "$command"
+
+command="ipfs pin ls --quiet --type recursive > $FILE_STORE_SNAP_NAME"
+echo "$(timestamp) store ipfs_id for gitter container in the file on the disk via '$command'"
+run_in_container "$command"

--- a/modules/cronjob_lotus_chain_snapshots/locals.tf
+++ b/modules/cronjob_lotus_chain_snapshots/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  pod_name = "${var.sts_name}-${var.sts_name_postfix}"
+}

--- a/modules/cronjob_lotus_chain_snapshots/main.tf
+++ b/modules/cronjob_lotus_chain_snapshots/main.tf
@@ -1,0 +1,129 @@
+resource "kubernetes_service_account_v1" "this" {
+  metadata {
+    name      = "${var.sts_name}-chain-snap-acc"
+    namespace = var.namespace
+  }
+}
+
+resource "kubernetes_role_v1" "this" {
+  metadata {
+    name      = "${var.sts_name}-chain-snap"
+    namespace = var.namespace
+  }
+
+  rule {
+    api_groups     = [""]
+    resources      = ["pods/exec"]
+    resource_names = [local.pod_name]
+    verbs          = ["create"]
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["pods"]
+    verbs      = ["get"]
+  }
+}
+
+resource "kubernetes_role_binding_v1" "this" {
+  metadata {
+    name      = "${var.sts_name}-chain-snap-binding"
+    namespace = var.namespace
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = kubernetes_role_v1.this.metadata[0].name
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account_v1.this.metadata[0].name
+    namespace = var.namespace
+  }
+}
+
+resource "kubernetes_cron_job_v1" "this" {
+  metadata {
+    name      = "${var.sts_name}-chain-snap-creator"
+    namespace = var.namespace
+  }
+  spec {
+    concurrency_policy            = "Forbid"
+    failed_jobs_history_limit     = 1
+    schedule                      = var.schedule
+    successful_jobs_history_limit = 1
+    job_template {
+      metadata {}
+      spec {
+        template {
+          metadata {}
+          spec {
+            service_account_name = kubernetes_service_account_v1.this.metadata[0].name
+            restart_policy       = "Never"
+            init_container {
+              name  = "${var.sts_name}-chain-snap-creator"
+              image = "bitnami/kubectl"
+              command = ["bash", "-c", templatefile("${path.module}/configs/creator/creator.sh", {
+                namespace        = var.namespace,
+                blocks_to_export = var.blocks_to_export
+                pod              = local.pod_name,
+                container        = "filecoin",
+                cur_snap         = "/data/ipfs/lotus-current.car"
+                new_snap         = "/data/ipfs/lotus-new.car"
+                shell            = "bash",
+                })
+              ]
+            }
+            init_container {
+              name  = "${var.sts_name}-chain-snap-sharer"
+              image = "bitnami/kubectl"
+              command = ["bash", "-c", templatefile("${path.module}/configs/sharer/sharer.sh", {
+                namespace        = var.namespace,
+                pod              = local.pod_name,
+                container        = "filecoin-ipfs",
+                cur_snap         = "/data/ipfs/lotus-current.car"
+                file_to_store_id = "/data/ipfs/current_snapshot.name",
+                shell            = "sh",
+                })
+              ]
+            }
+            container {
+              name  = "${var.sts_name}-chain-snap-gitter"
+              image = "bitnami/kubectl"
+              command = ["bash", "-c", templatefile("${path.module}/configs/gitter/gitter.sh", {
+                namespace        = var.namespace,
+                pod              = local.pod_name,
+                container        = "filecoin",
+                file_to_store_id = "/data/ipfs/current_snapshot.name",
+                shell            = "bash",
+                git_repo         = var.git_repo,
+                git_author       = var.git_author
+                git_email        = var.git_email
+                })
+              ]
+              #TODO: rewrite logic to remove this codesmell user 0 below
+              security_context {
+                run_as_user = 0
+              }
+              volume_mount {
+                name       = "chain-snap-ssh-secret"
+                mount_path = "/secret"
+                read_only  = true
+              }
+              env {
+                name  = "GIT_SSH_COMMAND"
+                value = "ssh -i /secret/ssh -o IdentitiesOnly=yes"
+              }
+            }
+            volume {
+              name = "chain-snap-ssh-secret"
+              secret {
+                secret_name  = "github-ssh-gist-updater"
+                default_mode = "0600"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/cronjob_lotus_chain_snapshots/variables.tf
+++ b/modules/cronjob_lotus_chain_snapshots/variables.tf
@@ -1,0 +1,36 @@
+variable "sts_name" {
+  type = string
+}
+
+variable "sts_name_postfix" {
+  type    = string
+  default = "lotus-0"
+}
+
+variable "namespace" {
+  type = string
+}
+
+variable "git_repo" {
+  type = string
+}
+
+variable "git_author" {
+  type    = string
+  default = "Protofire Bot"
+}
+
+variable "git_email" {
+  type    = string
+  default = "openworklabbot@gmail.com"
+}
+
+variable "schedule" {
+  type    = string
+  default = "0 0 * * *"
+}
+
+variable "blocks_to_export" {
+  type    = number
+  default = 900
+}


### PR DESCRIPTION
What was done:
* create cronjob for chain_snap as module,
* cronjob is using now init containers running one by one before main - (no more parallel containers with pgreps)
* add logging to scripts, 
* enhance scripts
* enabled against calibration 
---
Main goal have been achieved: 
* updated - https://gist.github.com/openworklabbot/95da15b014ffc3b5a170485001f46abd 
* QmUyRN98tC8ydrjSDKe6CJKjQLNU1wk2BgzcKuvkUogfBn is using as current snap and available via:
  * https://calibration.node.glif.io/calibrationapi/ipfs/8080/ipfs/QmUyRN98tC8ydrjSDKe6CJKjQLNU1wk2BgzcKuvkUogfBn)
---
Logs of test run:
calibrationapi-chain-snap-creator as the 1st init container: 
```
kubectl logs calibrationapi-chain-snap-creator-27759400-65dxg -c calibrationapi-chain-snap-creator -n network -f
2022-10-12_08:43:07 get current block height is 1383446, found by 'lotus chain list --count 1 --format "<height>"'
2022-10-12_08:43:07 started lotus snapshot export for 900 blocks via 'lotus chain export --tipset @1383446 --recent-stateroots 900     --skip-old-msgs /data/ipfs/lotus-new.car'
2022-10-12_09:03:31 finished lotus snapshot export for 900 blocks via 'lotus chain export --tipset @1383446 --recent-stateroots 900     --skip-old-msgs /data/ipfs/lotus-new.car'
2022-10-12_09:03:31 moving new on old chian_snap via mv /data/ipfs/lotus-new.car /data/ipfs/lotus-current.car
```
calibrationapi-chain-snap-sharer as the 2nd init container: 
```
2022-10-12_09:03:34 checking that chain_snap exist via '[ -s /data/ipfs/lotus-current.car ]'
2022-10-12_09:03:34 clean up old chain snapshot from ipfs via 'ipfs pin ls --quiet --type recursive | xargs ipfs pin rm && ipfs repo gc --silent'
unpinned QmcbTRMGhTrzKWLe5hsrqvJQ4xFAKxSS2fbKoZJaLt4VGo
2022-10-12_09:03:35 add chain_snap to ipfs via 'ipfs add /data/ipfs/lotus-current.car --quiet'
QmUyRN98tC8ydrjSDKe6CJKjQLNU1wk2BgzcKuvkUogfBn
2022-10-12_09:04:53 store ipfs_id for gitter container in the file on the disk via 'ipfs pin ls --quiet --type recursive > /data/ipfs/current_snapshot.name'
```
calibrationapi-chain-snap-gitter as the main container: 
```
2022-10-12_09:04:56 checking that ipfs_id in file exist via 'if [ -f /data/ipfs/current_snapshot.name ]; then cat /data/ipfs/current_snapshot.name; else exit 1; fi;'
2022-10-12_09:04:56 ipfs_id is QmUyRN98tC8ydrjSDKe6CJKjQLNU1wk2BgzcKuvkUogfBn
2022-10-12_09:04:56 installing git and ssh-keyscan from openssh-client
2022-10-12_09:04:59 fetching gist.github.com SSH keys
# gist.github.com:22 SSH-2.0-babeld-3f0fc83a
2022-10-12_09:05:00 cloning repo git@gist.github.com:95da15b014ffc3b5a170485001f46abd.git
Cloning into '/tmp/snapshots'...
Warning: Permanently added the RSA host key for IP address '20.27.177.113' to the list of known hosts.
2022-10-12_09:05:03 adding ipfs_id data
2022-10-12_09:05:03 going to /tmp/snapshots
2022-10-12_09:05:03 configuring git
2022-10-12_09:05:03 committing data
[master fa34270] new export
 1 file changed, 1 insertion(+), 1 deletion(-)
2022-10-12_09:05:03 pushing data...
To gist.github.com:95da15b014ffc3b5a170485001f46abd.git
   b429299..fa34270  master -> master
```