### PR TITLE
change repo back to protofire

### DIFF
--- a/aws/tfvars/filecoin-glif-dev-apn1.tfvars
+++ b/aws/tfvars/filecoin-glif-dev-apn1.tfvars
@@ -29,9 +29,9 @@ git_configuration = [
     config = {
       project_name      = "cid-checker",
       name              = "cid-checker"
-      organization_name = "glifio",
+      organization_name = "protofire",
       description       = "CI/CD pipeline for filecoin",
-      repo_name         = "cid-checker",
+      repo_name         = "filecoin-CID-checker",
     }
   },
 ]

--- a/aws/tfvars/filecoin-glif-mainnet-apn1.tfvars
+++ b/aws/tfvars/filecoin-glif-mainnet-apn1.tfvars
@@ -20,10 +20,9 @@ git_configuration = [
     config = {
       project_name      = "cid-checker",
       name              = "cid-checker"
-      organization_name = "glifio",
-      environment       = "mainnet",
+      organization_name = "protofire",
       description       = "CI/CD pipeline for filecoin",
-      repo_name         = "cid-checker",
+      repo_name         = "filecoin-CID-checker",
     }
   },
 ]


### PR DESCRIPTION
We agreed that we need to host CID Checker under Protofire repo (still in k8s cluster), so I changed that back