### PR TITLE
[fix] - add more space to mainnet monitoring, add ternary for the size of pvc

### DIFF
--- a/k8s/configs/prometheus/values.yaml
+++ b/k8s/configs/prometheus/values.yaml
@@ -160,7 +160,7 @@ prometheus:
             - ReadWriteOnce
           resources:
             requests:
-              storage: 100Gi
+              storage: ${get_pvc_size}
 
   additionalServiceMonitors:
     - name: lily-service

--- a/k8s/monitoring.tf
+++ b/k8s/monitoring.tf
@@ -1,3 +1,5 @@
+#TODO: probably, we should move this code to module, 'cause it will be easier to customize values and remaing defaults,
+#  but for now, I believe it will be enough and not critical
 resource "helm_release" "monitoring" {
   name       = "monitoring"
   repository = "https://prometheus-community.github.io/helm-charts"
@@ -17,6 +19,7 @@ resource "helm_release" "monitoring" {
       get_kong_ingress_external    = helm_release.konghq-external.name
       get_kong_ingress_internal    = helm_release.konghq-internal.name
       get_grafana_notif_url        = local.is_dev_envs == 1 ? "monitoring.dev.node.glif.io" : "monitoring.node.glif.io"
+      get_pvc_size                 = local.is_dev_envs == 1 ? "100Gi" : "210Gi"
     })
   ]
 


### PR DESCRIPTION
Notes:
* Current usage is 1.41GB per day
* Retention is 120 days
* 80% of usage in a threshold 
* 0.1$ per GP2
Calculation: 
* usage:
1.41*120/0.8==210 GB
* money:
210GB*0.1==21$ 