### PR TITLE
[fix] - change mainnet chain_snap module name to unique

### DIFF
--- a/k8s/modules_chain_snapshots_mainnet.tf
+++ b/k8s/modules_chain_snapshots_mainnet.tf
@@ -1,4 +1,4 @@
-module "calibrationapi_chain_snapshot" {
+module "mainnet_chain_snapshot" {
   count     = local.is_mainnet_envs
   source    = "../modules/cronjob_lotus_chain_snapshots"
   sts_name  = "space00"


### PR DESCRIPTION
I'm sorry, I haven't add good unique name for module