### PR TITLE
Blue green for wallaby deployments

### DIFF
--- a/aws/templates/codebuild/deploy_wallaby.yaml
+++ b/aws/templates/codebuild/deploy_wallaby.yaml
@@ -44,9 +44,12 @@ phases:
       - kubectl -n network scale --replicas 0 statefulset wallaby-archive-lotus
       - kubectl -n network delete pvc vol-lotus-wallaby-archive-lotus-0
       - kubectl -n network scale --replicas 1 statefulset wallaby-archive-lotus
+      - kubectl -n network wait --for=condition=ready pod/wallaby-archive-lotus-0
       - kubectl -n network scale --replicas 0 statefulset wallaby-archive-slave-lotus
       - kubectl -n network delete pvc vol-lotus-wallaby-archive-slave-lotus-0
       - kubectl -n network scale --replicas 1 statefulset wallaby-archive-slave-lotus
+      - kubectl -n network wait --for=condition=ready pod/wallaby-archive-slave-lotus-0
       - kubectl -n network scale --replicas 0 statefulset wallaby-archive-slave-1-lotus
       - kubectl -n network delete pvc vol-lotus-wallaby-archive-slave-1-lotus-0
       - kubectl -n network scale --replicas 1 statefulset wallaby-archive-slave-1-lotus
+      - kubectl -n network wait --for=condition=ready pod/wallaby-archive-slave-1-lotus-0


### PR DESCRIPTION
Since there are gonna be more redeployments soon without network reset - let's redeploy and wait till the node is up? It will decrease deployment speed, but make our deployment blue-green, decreasing downtime 🤔 