### PR TITLE
[feat] - Atlantis IP restriction

### DIFF
--- a/k8s/api_gateway_kong.tf
+++ b/k8s/api_gateway_kong.tf
@@ -12,7 +12,7 @@ module "api_gateway_kong_dev" {
   upstream_service = "api-read-dev-lotus"
 
   enable_mirroring = true
-  mirror_to        = [
+  mirror_to = [
     "https://kong-mirror.free.beeceptor.com"
   ]
 }
@@ -26,8 +26,8 @@ module "api_gateway_kong_mainnet" {
   stage_name  = "mainnet"
   domain_name = "api.node.glif.io"
 
-  ingress_class = "external"
-  namespace     = "network"
+  ingress_class    = "external"
+  namespace        = "network"
   upstream_service = "api-read-master-lotus"
 }
 
@@ -40,12 +40,12 @@ module "api_gateway_kong_mainnet_mirrored" {
   stage_name  = "mainnet"
   domain_name = "api.node.glif.io"
 
-  ingress_class = "mirror"
-  namespace     = "network"
+  ingress_class    = "mirror"
+  namespace        = "network"
   upstream_service = "api-read-master-mirrored-lotus"
 
   enable_mirroring = true
-  mirror_to        = [
+  mirror_to = [
     "https://mirror.node.glif.io"
   ]
 }
@@ -59,12 +59,12 @@ module "api_gateway_kong_mainnet_mirrored2" {
   stage_name  = "mainnet"
   domain_name = "api.node.glif.io"
 
-  ingress_class = "mirror2"
-  namespace     = "network"
+  ingress_class    = "mirror2"
+  namespace        = "network"
   upstream_service = "api-read-master-mirrored-lotus"
 
   enable_mirroring = true
-  mirror_to        = [
+  mirror_to = [
     "https://mirror2.node.glif.io"
   ]
 }
@@ -111,7 +111,7 @@ module "api_gateway_kong_hyperspace_mirrored" {
   upstream_service = "hyperspace-mirrored-lotus"
 
   enable_mirroring = true
-  mirror_to        = [
+  mirror_to = [
     "https://mirror.hyperspace.node.glif.io"
   ]
 }

--- a/k8s/kong_sticky_sessions.tf
+++ b/k8s/kong_sticky_sessions.tf
@@ -4,14 +4,14 @@ resource "kubernetes_manifest" "kong_sticky_sessions" {
     apiVersion = "configuration.konghq.com/v1"
     kind       = "KongIngress"
     metadata = {
-      name = "${terraform.workspace}-kong-sticky-sessions"
+      name      = "${terraform.workspace}-kong-sticky-sessions"
       namespace = kubernetes_namespace_v1.network.metadata[0].name
     }
 
     upstream = {
-      hash_on = "cookie"
+      hash_on        = "cookie"
       hash_on_cookie = "sticky"
-      algorithm = "consistent-hashing"
+      algorithm      = "consistent-hashing"
     }
 
     proxy = {

--- a/k8s/konghq.tf
+++ b/k8s/konghq.tf
@@ -8,7 +8,7 @@ resource "helm_release" "konghq-external" {
   version    = "2.13.0"
 
   values = [templatefile("${path.module}/configs/konghq/values.yaml", {
-    app = "${module.generator.prefix}-kong-external" 
+    app                        = "${module.generator.prefix}-kong-external"
     http_mirror_configmap_name = kubernetes_config_map.kong_plugin-http_mirror.metadata[0].name
   })]
 
@@ -121,7 +121,7 @@ resource "helm_release" "konghq-mirror" {
   version    = "2.13.0"
 
   values = [templatefile("${path.module}/configs/konghq/mirror.yaml", {
-    app = "${module.generator.prefix}-kong-mirror-1" 
+    app                        = "${module.generator.prefix}-kong-mirror-1"
     http_mirror_configmap_name = kubernetes_config_map.kong_plugin-http_mirror.metadata[0].name
   })]
 
@@ -234,7 +234,7 @@ resource "helm_release" "konghq-mirror2" {
   version    = "2.13.0"
 
   values = [templatefile("${path.module}/configs/konghq/mirror.yaml", {
-    app = "${module.generator.prefix}-kong-mirror-2" 
+    app                        = "${module.generator.prefix}-kong-mirror-2"
     http_mirror_configmap_name = kubernetes_config_map.kong_plugin-http_mirror.metadata[0].name
   })]
 

--- a/k8s/modules-ingress-mainnet.tf
+++ b/k8s/modules-ingress-mainnet.tf
@@ -623,7 +623,7 @@ module "ingress-atlantis-80" {
   type_lb_scheme                     = "external"
 
   enable_whitelist_ip = true
-  get_whitelist_ips   = [
+  get_whitelist_ips = [
     "64.78.234.192/27"
   ]
 }

--- a/k8s/modules-ingress-mainnet.tf
+++ b/k8s/modules-ingress-mainnet.tf
@@ -621,6 +621,11 @@ module "ingress-atlantis-80" {
   is_kong_auth_header_enabled        = false
   is_kong_transformer_header_enabled = false
   type_lb_scheme                     = "external"
+
+  enable_whitelist_ip = true
+  get_whitelist_ips   = [
+    "64.78.234.192/27"
+  ]
 }
 
 ###### Ingresses for mirror nodes ##########

--- a/k8s/route53.tf
+++ b/k8s/route53.tf
@@ -164,7 +164,7 @@ resource "aws_route53_record" "api_hyperspace_node_glif_io_mirrored" {
 
   set_identifier = "hyperspace-mirror"
   weighted_routing_policy {
-    weight = 0
+    weight = 1
   }
 }
 
@@ -297,7 +297,7 @@ resource "aws_route53_record" "api-internal_node_glif_io_mirrored2" {
 
   set_identifier = "mainnet-mirror2"
   weighted_routing_policy {
-    weight = 0
+    weight = 1
   }
 }
 


### PR DESCRIPTION
Changes:
- Atlantis UI is now available only from the Denver datacenter IP addresses.
- The amount of traffic to mirror has been adjusted.
- Fixed code formatting in k8s module.