### PR TITLE
[fix] - Rename group16 to api-read-slave-0

### DIFF
--- a/aws/nodegroup_mainnet.tf
+++ b/aws/nodegroup_mainnet.tf
@@ -60,7 +60,7 @@ module "eks_nodegroup_ondemand_group16" {
   count  = local.is_prod_envs
   source = "../modules/eks_nodegroup"
 
-  name          = "group16"
+  name          = "api-read-slave-0"
   instance_type = "r6gd.4xlarge"
   ami_type      = "AL2_ARM_64"
   user_data     = "nvme-spot.sh"

--- a/modules/uptimerobot_cache/lambda.tf
+++ b/modules/uptimerobot_cache/lambda.tf
@@ -11,7 +11,7 @@ resource "aws_lambda_function" "default" {
   filename         = data.archive_file.default.output_path
   source_code_hash = data.archive_file.default.output_base64sha256
 
-  runtime = "nodejs12.x"
+  runtime = "nodejs16.x"
   handler = "index.handler"
   timeout = 300
 


### PR DESCRIPTION
Also:
- Bump UptimeRobot Cache lambda runtime to nodejs16.x