### PR TITLE
[chore] - Shut down space06 and coinfirm

### DIFF
--- a/aws/nodegroup_mainnet.tf
+++ b/aws/nodegroup_mainnet.tf
@@ -138,25 +138,12 @@ module "eks_nodegroup_ondemand_fvm_archive" {
   nodegroup_config = local.make_eks_nodegroups_global_configuration
 }
 
-module "eks_nodegroup_ondemand_confirm_0" {
-  count  = local.is_prod_envs
-  source = "../modules/eks_nodegroup"
-
-  name          = "coinfirm-0"
-  instance_type = "r6gd.4xlarge"
-  ami_type      = "AL2_ARM_64"
-  user_data     = "nvme-spot.sh"
-
-  global_config    = local.make_global_configuration
-  nodegroup_config = local.make_eks_nodegroups_global_configuration
-}
-
 module "eks_nodegroup_ondemand_calibnet_0" {
   count  = local.is_prod_envs
   source = "../modules/eks_nodegroup"
 
   name          = "calibnet-0"
-  instance_type = "c6g.4xlarge"
+  instance_type = "r6gd.xlarge"
   ami_type      = "AL2_ARM_64"
   user_data     = "nvme-spot.sh"
 
@@ -173,7 +160,7 @@ module "eks_nodegroup_spot_calibnet_1" {
   source = "../modules/eks_nodegroup"
 
   name             = "calibnet-1"
-  instance_type    = "c6g.4xlarge"
+  instance_type    = "r6gd.xlarge"
   ami_type         = "AL2_ARM_64"
   is_spot_instance = true
 

--- a/aws/nodegroup_mainnet.tf
+++ b/aws/nodegroup_mainnet.tf
@@ -108,33 +108,6 @@ module "eks_nodegroup_ondemand_group19" {
   nodegroup_config = local.make_eks_nodegroups_global_configuration
 }
 
-#module "eks_nodegroup_ondemand_group28" {
-#  count  = local.is_prod_envs
-#  source = "../modules/eks_nodegroup"
-#
-#  name          = "group28"
-#  instance_type = "r6gd.4xlarge"
-#  ami_type      = "AL2_ARM_64"
-#  user_data     = "nvme-spot.sh"
-#
-#  global_config    = local.make_global_configuration
-#  nodegroup_config = local.make_eks_nodegroups_global_configuration
-#}
-
-module "eks_nodegroup_ondemand_group29" {
-  count  = local.is_prod_envs
-  source = "../modules/eks_nodegroup"
-
-  name          = "space06"
-  instance_type = "r6gd.8xlarge"
-  ami_type      = "AL2_ARM_64"
-  user_data     = "nvme-spot.sh"
-  is_critical   = true
-
-  global_config    = local.make_global_configuration
-  nodegroup_config = local.make_eks_nodegroups_global_configuration
-}
-
 module "eks_nodegroup_ondemand_fvm_archive" {
   count  = local.is_prod_envs
   source = "../modules/eks_nodegroup"
@@ -200,20 +173,6 @@ module "eks_nodegroup_mainnet_spot_group9" {
   source = "../modules/eks_nodegroup"
 
   name             = "group9"
-  instance_type    = "r6gd.4xlarge"
-  ami_type         = "AL2_ARM_64"
-  is_spot_instance = true
-
-  global_config    = local.make_global_configuration
-  nodegroup_config = local.make_eks_nodegroups_global_configuration
-}
-
-#prod-space06-1-i3-2x4x-spot-a-1-19-Node
-module "eks_nodegroup_mainnet_spot_group10" {
-  count  = local.is_prod_envs
-  source = "../modules/eks_nodegroup"
-
-  name             = "group10"
   instance_type    = "r6gd.4xlarge"
   ami_type         = "AL2_ARM_64"
   is_spot_instance = true

--- a/aws/nodegroup_mainnet.tf
+++ b/aws/nodegroup_mainnet.tf
@@ -53,6 +53,19 @@ module "eks_nodegroup_ondemand_group16" {
   nodegroup_config = local.make_eks_nodegroups_global_configuration
 }
 
+module "eks_nodegroup_ondemand_api-read-cid-checker" {
+  count  = local.is_prod_envs
+  source = "../modules/eks_nodegroup"
+
+  name          = "api-read-cid-checker"
+  instance_type = "r6gd.8xlarge"
+  ami_type      = "AL2_ARM_64"
+  user_data     = "nvme-spot.sh"
+
+  global_config    = local.make_global_configuration
+  nodegroup_config = local.make_eks_nodegroups_global_configuration
+}
+
 module "eks_nodegroup_ondemand_group17" {
   count  = local.is_prod_envs
   source = "../modules/eks_nodegroup"

--- a/aws/secrets_envs.tf
+++ b/aws/secrets_envs.tf
@@ -67,33 +67,6 @@ resource "aws_secretsmanager_secret" "api_read_master_lotus" {
   module.generator.common_tags)
 }
 
-resource "aws_secretsmanager_secret" "space06_lotus" {
-  count                   = local.is_prod_envs
-  name                    = "${module.generator.prefix}-space06-lotus"
-  recovery_window_in_days = 30
-
-  tags = merge({ "Name" = "${module.generator.prefix}-space06-lotus" },
-  module.generator.common_tags)
-}
-
-resource "aws_secretsmanager_secret" "space06_cache" {
-  count                   = local.is_prod_envs
-  name                    = "${module.generator.prefix}-space06-cache"
-  recovery_window_in_days = 30
-
-  tags = merge({ "Name" = "${module.generator.prefix}-space06-cache" },
-  module.generator.common_tags)
-}
-
-resource "aws_secretsmanager_secret" "space06-1_lotus" {
-  count                   = local.is_prod_envs
-  name                    = "${module.generator.prefix}-space06-1-lotus"
-  recovery_window_in_days = 30
-
-  tags = merge({ "Name" = "${module.generator.prefix}-space06-1-lotus" },
-  module.generator.common_tags)
-}
-
 resource "aws_secretsmanager_secret" "space07_lotus" {
   count                   = local.is_prod_envs
   name                    = "${module.generator.prefix}-space07-lotus"

--- a/k8s/data.tf
+++ b/k8s/data.tf
@@ -137,26 +137,6 @@ data "aws_secretsmanager_secret_version" "api_read_master_mainnet_lotus" {
   secret_id = data.aws_secretsmanager_secret.api_read_master_mainnet_lotus[0].id
 }
 
-data "aws_secretsmanager_secret" "space06_mainnet_lotus" {
-  count = local.is_prod_envs
-  name  = "${module.generator.prefix}-space06-lotus"
-}
-
-data "aws_secretsmanager_secret_version" "space06_mainnet_lotus" {
-  count     = local.is_prod_envs
-  secret_id = data.aws_secretsmanager_secret.space06_mainnet_lotus[0].id
-}
-
-data "aws_secretsmanager_secret" "space06_1_mainnet_lotus" {
-  count = local.is_prod_envs
-  name  = "${module.generator.prefix}-space06-1-lotus"
-}
-
-data "aws_secretsmanager_secret_version" "space06_1_mainnet_lotus" {
-  count     = local.is_prod_envs
-  secret_id = data.aws_secretsmanager_secret.space06_1_mainnet_lotus[0].id
-}
-
 data "aws_secretsmanager_secret" "space07_mainnet_lotus" {
   count = local.is_prod_envs
   name  = "${module.generator.prefix}-space07-lotus"
@@ -175,16 +155,6 @@ data "aws_secretsmanager_secret" "fvm_archive_lotus" {
 data "aws_secretsmanager_secret_version" "fvm_archive_lotus" {
   count     = local.is_prod_envs
   secret_id = data.aws_secretsmanager_secret.fvm_archive_lotus[0].id
-}
-
-data "aws_secretsmanager_secret" "space06_cache_mainnet_lotus" {
-  count = local.is_prod_envs
-  name  = "${module.generator.prefix}-space06-cache"
-}
-
-data "aws_secretsmanager_secret_version" "space06_cache_mainnet_lotus" {
-  count     = local.is_prod_envs
-  secret_id = data.aws_secretsmanager_secret.space06_cache_mainnet_lotus[0].id
 }
 
 data "aws_secretsmanager_secret" "space07_cache_mainnet_lotus" {

--- a/k8s/modules-ingress-mainnet.tf
+++ b/k8s/modules-ingress-mainnet.tf
@@ -230,17 +230,30 @@ module "ingress-kong_cid-checker-alternative-domain-mainnet-docs-subresources" {
 }
 
 #############node.glif.io##########################
+module "ingress_space06" {
+  count = local.is_prod_envs
 
-module "ingress-kong_space06-1234" {
-  count                            = local.is_prod_envs
-  source                           = "../modules/k8s_ingress"
-  get_global_configuration         = local.make_global_configuration
-  get_ingress_http_path            = "/space06/lotus/(.*)"
-  get_ingress_backend_service_name = "space06-lotus" // the "-service" string will be added automatically
-  get_ingress_backend_service_port = 1234
-  get_ingress_namespace            = kubernetes_namespace_v1.network.metadata[0].name
-  get_rule_host                    = "node.glif.io"
-  type_lb_scheme                   = "external"
+  name   = "space06-forwarding"
+  source = "../modules/ovh_ingress"
+
+  namespace = "network"
+
+  http_host = "node.glif.io"
+  http_path = "/space06/lotus/(.*)"
+
+  service_name = "api-read-master-lotus-service"
+  service_port  = 1234
+
+  incress_class = "kong-external-lb"
+
+  secret_name = data.aws_secretsmanager_secret.api_read_master_mainnet_lotus[0].name
+
+  enable_path_transformer = true
+  enable_access_control   = true
+  access_control_public   = true
+  access_control_replace  = true
+  enable_letsencrypt      = false
+  enable_return_json      = true
 }
 
 
@@ -373,18 +386,30 @@ module "ingress-atlantis-80" {
   ]
 }
 
-module "ingress-kong_coinfirm" {
-  count                            = local.is_prod_envs
-  source                           = "../modules/k8s_ingress"
-  get_global_configuration         = local.make_global_configuration
-  get_ingress_http_path            = "/coinfirm/lotus/(.*)"
-  get_ingress_backend_service_name = "fvm-archive-lotus" // the "-service" string will be added automatically
-  get_ingress_backend_service_port = 1234
-  get_ingress_namespace            = kubernetes_namespace_v1.network.metadata[0].name
-  get_rule_host                    = "node.glif.io"
-  type_lb_scheme                   = "external"
+module "ingress_coinfirm" {
+  count = local.is_prod_envs
 
-  return_json = true
+  name   = "coinfirm-forwarding"
+  source = "../modules/ovh_ingress"
+
+  namespace = "network"
+
+  http_host = "node.glif.io"
+  http_path = "/coinfirm/lotus/(.*)"
+
+  service_name = "fvm-archive-lotus-service"
+  service_port  = 1234
+
+  incress_class = "kong-external-lb"
+
+  secret_name = data.aws_secretsmanager_secret.fvm_archive_lotus[0].name
+
+  enable_path_transformer = true
+  enable_access_control   = true
+  access_control_public   = true
+  access_control_replace  = true
+  enable_letsencrypt      = false
+  enable_return_json      = true
 }
 
 module "ingress_private_mainnet_fallback" {

--- a/k8s/modules-ingress-mainnet.tf
+++ b/k8s/modules-ingress-mainnet.tf
@@ -270,18 +270,6 @@ module "ingress-kong_fvm-archive-1234" {
   return_json                      = true
 }
 
-module "ingress-kong_space06-cache-8080" {
-  count                            = local.is_prod_envs
-  source                           = "../modules/k8s_ingress"
-  get_global_configuration         = local.make_global_configuration
-  get_ingress_http_path            = "/space06/cache/(.*)"
-  get_ingress_backend_service_name = "space06-cache" // the "-service" string will be added automatically
-  get_ingress_backend_service_port = 8080
-  get_ingress_namespace            = kubernetes_namespace_v1.network.metadata[0].name
-  get_rule_host                    = "node.glif.io"
-  type_lb_scheme                   = "external"
-}
-
 module "ingress-kong_space07-cache-8080" {
   count                            = local.is_prod_envs
   source                           = "../modules/k8s_ingress"

--- a/k8s/modules-ingress-mainnet.tf
+++ b/k8s/modules-ingress-mainnet.tf
@@ -378,7 +378,7 @@ module "ingress-kong_coinfirm" {
   source                           = "../modules/k8s_ingress"
   get_global_configuration         = local.make_global_configuration
   get_ingress_http_path            = "/coinfirm/lotus/(.*)"
-  get_ingress_backend_service_name = "coinfirm-lotus" // the "-service" string will be added automatically
+  get_ingress_backend_service_name = "fvm-archive-lotus" // the "-service" string will be added automatically
   get_ingress_backend_service_port = 1234
   get_ingress_namespace            = kubernetes_namespace_v1.network.metadata[0].name
   get_rule_host                    = "node.glif.io"

--- a/k8s/modules-ingress-mainnet.tf
+++ b/k8s/modules-ingress-mainnet.tf
@@ -242,7 +242,7 @@ module "ingress_space06" {
   http_path = "/space06/lotus/(.*)"
 
   service_name = "api-read-master-lotus-service"
-  service_port  = 1234
+  service_port = 1234
 
   incress_class = "kong-external-lb"
 
@@ -398,7 +398,7 @@ module "ingress_coinfirm" {
   http_path = "/coinfirm/lotus/(.*)"
 
   service_name = "fvm-archive-lotus-service"
-  service_port  = 1234
+  service_port = 1234
 
   incress_class = "kong-external-lb"
 

--- a/k8s/secrets.tf
+++ b/k8s/secrets.tf
@@ -154,31 +154,6 @@ resource "kubernetes_secret_v1" "api_read_slave_10_mainnet_lotus_secret" {
   }
 }
 
-
-resource "kubernetes_secret_v1" "space06_mainnet_lotus_secret" {
-  count = local.is_prod_envs
-  metadata {
-    name      = "space06-lotus-secret"
-    namespace = kubernetes_namespace_v1.network.metadata[0].name
-  }
-  data = {
-    privatekey = lookup(jsondecode(data.aws_secretsmanager_secret_version.space06_mainnet_lotus[0].secret_string), "private_key", null)
-    token      = lookup(jsondecode(data.aws_secretsmanager_secret_version.space06_mainnet_lotus[0].secret_string), "jwt_token", null)
-  }
-}
-
-resource "kubernetes_secret_v1" "space06_1_mainnet_lotus_secret" {
-  count = local.is_prod_envs
-  metadata {
-    name      = "space06-1-lotus-secret"
-    namespace = kubernetes_namespace_v1.network.metadata[0].name
-  }
-  data = {
-    privatekey = lookup(jsondecode(data.aws_secretsmanager_secret_version.space06_1_mainnet_lotus[0].secret_string), "private_key", null)
-    token      = lookup(jsondecode(data.aws_secretsmanager_secret_version.space06_1_mainnet_lotus[0].secret_string), "jwt_token", null)
-  }
-}
-
 resource "kubernetes_secret_v1" "space07_mainnet_lotus_secret" {
   count = local.is_prod_envs
   metadata {
@@ -201,17 +176,6 @@ resource "kubernetes_secret_v1" "fvm_archive_lotus" {
   data = {
     privatekey = lookup(jsondecode(data.aws_secretsmanager_secret_version.fvm_archive_lotus[0].secret_string), "private_key", null)
     token      = lookup(jsondecode(data.aws_secretsmanager_secret_version.fvm_archive_lotus[0].secret_string), "jwt_token", null)
-  }
-}
-
-resource "kubernetes_secret_v1" "space06_cache_lotus_secret" {
-  count = local.is_prod_envs
-  metadata {
-    name      = "space06-cache-secret"
-    namespace = kubernetes_namespace_v1.network.metadata[0].name
-  }
-  data = {
-    config = base64decode(lookup(jsondecode(data.aws_secretsmanager_secret_version.space06_cache_mainnet_lotus[0].secret_string), "cache_service_config", null))
   }
 }
 

--- a/k8s/secrets.tf
+++ b/k8s/secrets.tf
@@ -94,6 +94,18 @@ resource "kubernetes_secret_v1" "api_read_slave_0_mainnet_lotus_secret" {
   }
 }
 
+resource "kubernetes_secret_v1" "api_read_cid_checker_secret" {
+  count = local.is_prod_envs
+  metadata {
+    name      = "api-read-cid-checker-lotus-secret"
+    namespace = kubernetes_namespace_v1.network.metadata[0].name
+  }
+  data = {
+    privatekey = lookup(jsondecode(data.aws_secretsmanager_secret_version.api_read_master_mainnet_lotus[0].secret_string), "private_key", null)
+    token      = lookup(jsondecode(data.aws_secretsmanager_secret_version.api_read_master_mainnet_lotus[0].secret_string), "jwt_token", null)
+  }
+}
+
 resource "kubernetes_secret_v1" "api_read_slave_1_mainnet_lotus_secret" {
   count = local.is_prod_envs
   metadata {


### PR DESCRIPTION
This PR introduces the following changes:

- `space06` ingress has been rewritten using `ovh_ingress` module. The ingress points to `api-read-master` service and replaces any token provided with the correct one to not disrupt the current client workflow.
- `coinfirm` ingress has been rewritten using `ovh_ingress` module. The ingress points to `fvm-archive` service and replaces any token provided with the correct one to not disrupt the current client workflow.
- `calibnet` instances types has been changed to `r6gd.xlarge` to reflect the current state of affairs.
- `api-read-cid-checker` node group and secret have been introduced as a replacement for the discontinued `space06`.
- `space06` resources have been removed except for the ingress that now points to `api-read-master` service.
- `coinfirm` resources have been removed except for the ingress that now points to `fvm-archive` service.