### PR TITLE
[feat] - enable external-auth for calibration-archive

### DIFF
--- a/k8s/modules-ingress-mainnet.tf
+++ b/k8s/modules-ingress-mainnet.tf
@@ -361,17 +361,30 @@ module "ingress-kong_api-read-dev-lotus-2346" {
   is_kong_auth_header_block_public_access = false
 }
 
-
 module "ingress-kong_calibrationapi-node-archive" {
-  count                            = local.is_prod_envs
-  source                           = "../modules/k8s_ingress"
-  get_global_configuration         = local.make_global_configuration
-  get_ingress_http_path            = "/archive/lotus/(.*)"
-  get_ingress_backend_service_name = "calibrationapi-archive-node-lotus" // the "-service" string will be added automatically
-  get_ingress_backend_service_port = 1234
-  get_ingress_namespace            = kubernetes_namespace_v1.network.metadata[0].name
-  get_rule_host                    = "calibration.node.glif.io"
-  type_lb_scheme                   = "external"
+  count = local.is_prod_envs
+
+  name   = "calibration-archive-forwarding"
+  source = "../modules/ovh_ingress"
+
+  namespace = "network"
+
+  http_host = "calibration.node.glif.io"
+  http_path = "/archive/lotus/(.*)"
+
+  service_name = "calibrationapi-archive-node-lotus-service"
+  service_port = 1234
+
+  ingress_class = "kong-external-lb"
+
+  secret_name = data.aws_secretsmanager_secret.calibrationapi_archive_node_lotus[0].name
+
+  enable_path_transformer = true
+  enable_access_control   = true
+  access_control_public   = true
+  access_control_replace  = true
+  enable_return_json      = true
+  enable_ext_token_auth   = true
 }
 
 


### PR DESCRIPTION
Created a legacy token for the node in the auth app. It should be deleted once all users switch to the new authorization tokens.